### PR TITLE
feat: extract shared MCP infrastructure into dedicated plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,6 +5,11 @@
 	},
 	"plugins": [
 		{
+			"name": "shared-mcp",
+			"source": "./plugins/00-shared-mcp",
+			"description": "Shared MCP infrastructure (Tavily, Jina, Exa) - install first as dependency for other plugins"
+		},
+		{
 			"name": "test-plugin",
 			"source": "./plugins/00-test",
 			"description": "My TEST ONLY plugin"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,10 +136,26 @@ Commands are invoked as: `/plugin-name:command-name`
 
 ## Current Plugins
 
+- **00-shared-mcp** (`./plugins/00-shared-mcp`): **INSTALL FIRST** - Shared MCP infrastructure providing common web search (Tavily, Exa) and content extraction (Jina) tools. Required by p-assist and common-engineering plugins.
 - **00-test** (`./plugins/00-test`): Test plugin for learning the basics
-- **01-p-assist** (`./plugins/01-p-assist`): Productivity plugin for article summarization, journal management (Logseq), and bookmark organization (Linkwarden). **Requires environment variables** - see `plugins/01-p-assist/README.md` for setup instructions.
-- **02-common-engineering** (`./plugins/02-common-engineering`): Essential toolkit for software engineers with Mermaid diagram generation, automatic validation, and self-healing capabilities.
+- **01-p-assist** (`./plugins/01-p-assist`): Productivity plugin for article summarization, journal management (Logseq), and bookmark organization (Linkwarden). **Requires shared-mcp plugin** - see `plugins/01-p-assist/README.md` for setup instructions.
+- **02-common-engineering** (`./plugins/02-common-engineering`): Essential toolkit for software engineers with Mermaid diagram generation, automatic validation, and self-healing capabilities. **Requires shared-mcp plugin** for web research features.
 - **03-sys-maint** (`./plugins/03-sys-maint`): System maintenance and cleanup utilities for Docker and disk space management with interactive preview and confirmation workflows.
+
+## Plugin Dependencies
+
+Some plugins depend on others. Install dependencies first:
+
+```
+shared-mcp (install first)
+├── p-assist (depends on shared-mcp for Tavily, Jina)
+└── common-engineering (depends on shared-mcp for Exa)
+```
+
+Installation order:
+1. `/plugin install shared-mcp@my-claude-code-marketplace`
+2. `/plugin install p-assist@my-claude-code-marketplace` (optional)
+3. `/plugin install common-engineering@my-claude-code-marketplace` (optional)
 
 ## Adding a Command to an Existing Plugin
 

--- a/plugins/00-shared-mcp/.claude-plugin/plugin.json
+++ b/plugins/00-shared-mcp/.claude-plugin/plugin.json
@@ -1,0 +1,48 @@
+{
+	"name": "shared-mcp",
+	"description": "Shared MCP infrastructure providing common web search, content extraction, and research tools for other plugins",
+	"version": "1.0.0",
+	"author": {
+		"name": "irfansofyana"
+	},
+	"mcpServers": {
+		"tavily": {
+			"type": "stdio",
+			"command": "npx",
+			"args": [
+				"-y",
+				"mcp-remote",
+				"https://mcp.tavily.com/mcp/?tavilyApiKey=${TAVILY_API_KEY}"
+			],
+			"env": {
+				"TAVILY_API_KEY": "${TAVILY_API_KEY}"
+			}
+		},
+		"jina": {
+			"type": "stdio",
+			"command": "npx",
+			"args": [
+				"-y",
+				"mcp-remote",
+				"https://mcp.jina.ai/sse",
+				"--header",
+				"Authorization: Bearer ${JINA_API_KEY}"
+			],
+			"env": {
+				"JINA_API_KEY": "${JINA_API_KEY}"
+			}
+		},
+		"exa": {
+			"type": "stdio",
+			"command": "npx",
+			"args": [
+				"-y",
+				"mcp-remote",
+				"https://mcp.exa.ai/mcp?exaApiKey=${EXA_API_KEY}&tools=web_search_exa,get_code_context_exa,crawling_exa,company_research_exa,linkedin_search_exa,deep_researcher_start,deep_researcher_check"
+			],
+			"env": {
+				"EXA_API_KEY": "${EXA_API_KEY}"
+			}
+		}
+	}
+}

--- a/plugins/00-shared-mcp/README.md
+++ b/plugins/00-shared-mcp/README.md
@@ -1,0 +1,91 @@
+# Shared MCP Plugin
+
+Shared MCP infrastructure providing common web search, content extraction, and research tools that other plugins can use.
+
+## Purpose
+
+This plugin consolidates commonly-used MCP servers to:
+- Reduce configuration overhead (configure API keys once)
+- Share MCP server processes across plugins
+- Provide consistent tool naming
+- Simplify plugin dependencies
+
+## Prerequisites
+
+- Node.js (for npx)
+- npm
+
+## MCP Servers Included
+
+| Server | Purpose | Tools Provided |
+|--------|---------|----------------|
+| **Tavily** | Web search and content extraction | `tavily_search`, `tavily_extract`, `tavily_crawl`, `tavily_map` |
+| **Jina** | Content reading and URL processing | `read_url`, `search_web`, `search_images`, `search_arxiv`, and more |
+| **Exa** | AI-powered web search and code context | `web_search_exa`, `get_code_context_exa`, `crawling_exa`, `deep_researcher_start/check` |
+
+## Installation
+
+### 1. Install the plugin
+
+```bash
+/plugin install shared-mcp@my-claude-code-marketplace
+```
+
+### 2. Configure Environment Variables
+
+Add the following to your environment or Claude Code settings:
+
+```bash
+# Tavily API Key (https://tavily.com)
+export TAVILY_API_KEY="your-tavily-api-key"
+
+# Jina API Key (https://jina.ai)
+export JINA_API_KEY="your-jina-api-key"
+
+# Exa API Key (https://exa.ai)
+export EXA_API_KEY="your-exa-api-key"
+```
+
+**Getting API Keys:**
+- **Tavily**: Sign up at [tavily.com](https://tavily.com) - Free tier available
+- **Jina**: Sign up at [jina.ai](https://jina.ai) - Free tier available
+- **Exa**: Sign up at [exa.ai](https://exa.ai) - Free tier available
+
+## Tool Name Format
+
+Tools from this plugin follow the naming pattern:
+```
+mcp__plugin_shared-mcp_[server]__[tool_name]
+```
+
+**Examples:**
+- `mcp__plugin_shared-mcp_tavily__tavily_search`
+- `mcp__plugin_shared-mcp_jina__read_url`
+- `mcp__plugin_shared-mcp_exa__web_search_exa`
+
+## Plugins That Depend on This
+
+The following plugins require `shared-mcp` to be installed:
+
+- **p-assist**: Uses Tavily and Jina for article summarization and web content extraction
+- **common-engineering**: Uses Exa for web research and code context
+
+## Troubleshooting
+
+### MCP server not starting
+
+1. Ensure environment variables are set correctly
+2. Check that `npx` is available in your PATH
+3. Verify API keys are valid
+
+### Tool not found
+
+Ensure the plugin is installed and enabled:
+```bash
+/plugin list
+/plugin enable shared-mcp@my-claude-code-marketplace
+```
+
+## Version History
+
+- **1.0.0**: Initial release with Tavily, Jina, and Exa MCP servers

--- a/plugins/01-p-assist/.claude-plugin/plugin.json
+++ b/plugins/01-p-assist/.claude-plugin/plugin.json
@@ -20,32 +20,6 @@
         		"LOGSEQ_API_URL": "http://localhost:12315"
       		}
     	},
-		"tavily": {
-			"type": "stdio",
-			"command": "npx",
-			"args": [
-				"-y",
-				"mcp-remote",
-				"https://mcp.tavily.com/mcp/?tavilyApiKey=${TAVILY_API_KEY}"
-			],
-			"env": {
-				"TAVILY_API_KEY": "${TAVILY_API_KEY}"
-			}
-		},
-		"jina": {
-			"type": "stdio",
-			"command": "npx",
-			"args": [
-				"-y",
-				"mcp-remote",
-				"https://mcp.jina.ai/sse",
-				"--header",
-				"Authorization: Bearer ${JINA_API_KEY}"
-			],
-			"env": {
-				"JINA_API_KEY": "${JINA_API_KEY}"
-			}
-    	},
 		"linkwd": {
       		"type": "stdio",
       		"command": "docker",

--- a/plugins/01-p-assist/README.md
+++ b/plugins/01-p-assist/README.md
@@ -2,18 +2,40 @@
 
 A comprehensive productivity plugin for Claude Code that provides article summarization, journal management (Logseq), and bookmark organization (Linkwarden) capabilities.
 
+## Prerequisites
+
+**Important**: This plugin requires the `shared-mcp` plugin to be installed first. The shared-mcp plugin provides common MCP servers (Tavily, Jina) used for web search and content extraction.
+
+```bash
+# Install shared-mcp first
+/plugin install shared-mcp@my-claude-code-marketplace
+
+# Then install p-assist
+/plugin install p-assist@my-claude-code-marketplace
+```
+
 ## Features
 
-- **Article Summarization**: Extract and summarize web articles using Tavily, optionally save to Linkwarden
+- **Article Summarization**: Extract and summarize web articles using Tavily (from shared-mcp), optionally save to Linkwarden
 - **Journal Management**: Create and search Logseq journal entries
 - **Bookmark Management**: Save and organize bookmarks in Linkwarden
-- **Web Research**: AI-powered web search and content extraction using Tavily and Jina
+- **Web Research**: AI-powered web search and content extraction using shared-mcp tools
 
 ## MCP Server Configuration
 
-This plugin uses MCP (Model Context Protocol) servers to integrate with external services. You'll need to configure the following environment variables:
+This plugin uses MCP (Model Context Protocol) servers to integrate with external services.
 
-### Required Environment Variables
+### Dependency: shared-mcp Plugin
+
+The following services are provided by the `shared-mcp` plugin (install it first):
+- **Tavily**: Web search and content extraction
+- **Jina**: Advanced web reading and content processing
+
+See the [shared-mcp README](../00-shared-mcp/README.md) for API key configuration.
+
+### Plugin-Specific Environment Variables
+
+These environment variables are specific to p-assist:
 
 #### Logseq Integration (`logseq`)
 - `LOGSEQ_API_TOKEN`: Your Logseq API token
@@ -26,39 +48,27 @@ This plugin uses MCP (Model Context Protocol) servers to integrate with external
 - `LINKWARDEN_TOKEN`: Your Linkwarden API token
   - Get this from your Linkwarden account settings
 
-#### Tavily Integration (`tavily`)
-- `TAVILY_API_KEY`: Your Tavily API key
-  - Get this from [Tavily API](https://tavily.com/)
-
-#### Jina Integration (`jina`)
-- `JINA_API_KEY`: Your Jina API key
-  - Get this from [Jina AI](https://jina.ai/)
-
 ### Setup Instructions
 
-1. **Set up Logseq:**
+1. **Install and configure shared-mcp first** (for Tavily and Jina):
+   ```bash
+   /plugin install shared-mcp@my-claude-code-marketplace
+   ```
+   See [shared-mcp README](../00-shared-mcp/README.md) for API key setup.
+
+2. **Set up Logseq:**
    ```bash
    export LOGSEQ_API_TOKEN="your_logseq_api_token_here"
    export LOGSEQ_API_URL="http://localhost:12315"  # or your Logseq instance URL
    ```
 
-2. **Set up Linkwarden:**
+3. **Set up Linkwarden:**
    ```bash
    export LINKWARDEN_BASE_URL="https://your-linkwarden-instance.com"
    export LINKWARDEN_TOKEN="your_linkwarden_api_token_here"
    ```
 
-3. **Set up Tavily:**
-   ```bash
-   export TAVILY_API_KEY="your_tavily_api_key_here"
-   ```
-
-4. **Set up Jina:**
-   ```bash
-   export JINA_API_KEY="your_jina_api_key_here"
-   ```
-
-5. **For persistent configuration**, add these to your shell profile (`~/.zshrc`, `~/.bashrc`, etc.):
+4. **For persistent configuration**, add these to your shell profile (`~/.zshrc`, `~/.bashrc`, etc.):
    ```bash
    # Logseq
    export LOGSEQ_API_TOKEN="your_logseq_api_token_here"
@@ -67,12 +77,6 @@ This plugin uses MCP (Model Context Protocol) servers to integrate with external
    # Linkwarden
    export LINKWARDEN_BASE_URL="https://your-linkwarden-instance.com"
    export LINKWARDEN_TOKEN="your_linkwarden_api_token_here"
-
-   # Tavily
-   export TAVILY_API_KEY="your_tavily_api_key_here"
-
-   # Jina
-   export JINA_API_KEY="your_jina_api_key_here"
    ```
 
 ## Available Commands
@@ -141,10 +145,10 @@ The orchestrator agent automatically handles complex tasks that involve multiple
 - **Internet connection**: For web search and article fetching
 
 ### MCP Servers Used
-- **logseq**: Logseq integration server
-- **tavily**: AI-powered web search and content extraction
-- **jina**: Advanced web reading, screenshots, and image search
-- **linkwd**: Linkwarden bookmark management
+- **logseq** (p-assist): Logseq integration server
+- **linkwd** (p-assist): Linkwarden bookmark management
+- **tavily** (shared-mcp): AI-powered web search and content extraction
+- **jina** (shared-mcp): Advanced web reading, screenshots, and image search
 
 ## Troubleshooting
 

--- a/plugins/01-p-assist/agents/productivity-orchestrator.md
+++ b/plugins/01-p-assist/agents/productivity-orchestrator.md
@@ -1,7 +1,7 @@
 ---
 name: productivity-orchestrator
 description: Coordinate multi-step productivity workflows including research, summarization, bookmarking, and journal management. Use when user requests complex tasks involving multiple tools like saving articles, researching topics across sources, or creating comprehensive notes.
-tools: Read, Write, WebFetch, mcp__tavily__tavily_search, mcp__tavily__tavily_extract, mcp__jina__read_url, mcp__logseq__search, mcp__logseq__create_page, mcp__logseq__update_page, mcp__logseq__get_page_content, mcp__linkwd__create_link, mcp__linkwd__get_all_links, mcp__linkwd__get_all_collections, mcp__linkwd__search_links
+tools: Read, Write, WebFetch, mcp__plugin_shared-mcp_tavily__tavily_search, mcp__plugin_shared-mcp_tavily__tavily_extract, mcp__plugin_shared-mcp_jina__read_url, mcp__plugin_p-assist_logseq__search, mcp__plugin_p-assist_logseq__create_page, mcp__plugin_p-assist_logseq__update_page, mcp__plugin_p-assist_logseq__get_page_content, mcp__plugin_p-assist_linkwd__create_link, mcp__plugin_p-assist_linkwd__get_all_links, mcp__plugin_p-assist_linkwd__get_all_collections, mcp__plugin_p-assist_linkwd__search_links
 model: sonnet
 ---
 
@@ -13,19 +13,19 @@ You are a productivity orchestrator specializing in multi-step workflows that co
 
 ### 1. Research & Summarization Workflows
 - Extract article content with intelligent fallback:
-  - **Primary**: Use `mcp__tavily__tavily_extract` for specific URLs (faster, works for most articles)
-  - **Fallback**: Use `mcp__jina__read_url` if Tavily exceeds 25,000 token limit
+  - **Primary**: Use `mcp__plugin_shared-mcp_tavily__tavily_extract` for specific URLs (faster, works for most articles)
+  - **Fallback**: Use `mcp__plugin_shared-mcp_jina__read_url` if Tavily exceeds 25,000 token limit
   - Jina handles large content, PDFs, and complex pages better
-- Search the web using `mcp__tavily__tavily_search` for research topics
+- Search the web using `mcp__plugin_shared-mcp_tavily__tavily_search` for research topics
 - Analyze and create comprehensive summaries
 - Extract key insights, main points, and actionable takeaways
 - Format summaries in clear, scannable markdown
 
 ### 2. Knowledge Management (Logseq Integration)
-- Search journals: `mcp__logseq__search` with smart query parameters
-- Create journal entries: `mcp__logseq__create_page` with proper formatting
-- Update existing pages: `mcp__logseq__update_page` to add context
-- Retrieve page content: `mcp__logseq__get_page_content` for analysis
+- Search journals: `mcp__plugin_p-assist_logseq__search` with smart query parameters
+- Create journal entries: `mcp__plugin_p-assist_logseq__create_page` with proper formatting
+- Update existing pages: `mcp__plugin_p-assist_logseq__update_page` to add context
+- Retrieve page content: `mcp__plugin_p-assist_logseq__get_page_content` for analysis
 - Structure entries with:
   - Proper markdown formatting
   - Relevant #tags for discoverability
@@ -33,9 +33,9 @@ You are a productivity orchestrator specializing in multi-step workflows that co
   - Bullet points and hierarchical structure
 
 ### 3. Bookmark Organization (Linkwarden Integration)
-- Save links: `mcp__linkwd__create_link` with rich metadata
-- Search bookmarks: `mcp__linkwd__search_links` for discovery
-- List collections: `mcp__linkwd__get_all_collections` for organization
+- Save links: `mcp__plugin_p-assist_linkwd__create_link` with rich metadata
+- Search bookmarks: `mcp__plugin_p-assist_linkwd__search_links` for discovery
+- List collections: `mcp__plugin_p-assist_linkwd__get_all_collections` for organization
 - Auto-generate relevant tags based on content
 - Map bookmarks to appropriate collections
 
@@ -50,7 +50,7 @@ When user shares an article URL:
 
 ### Pattern 2: Research Compilation
 When user requests research on a topic:
-1. Search web with `mcp__tavily__tavily_search` to find relevant sources
+1. Search web with `mcp__plugin_shared-mcp_tavily__tavily_search` to find relevant sources
 2. Extract content from key sources (Tavily primary, Jina fallback for large content)
 3. Analyze and synthesize findings
 4. Create comprehensive Logseq page with:
@@ -72,8 +72,8 @@ When user requests a summary of recent activity:
 
 ### Pattern 4: Cross-Reference Queries
 When user asks about past notes/bookmarks:
-1. Search Logseq journals with `mcp__logseq__search`
-2. Search Linkwarden bookmarks with `mcp__linkwd__search_links`
+1. Search Logseq journals with `mcp__plugin_p-assist_logseq__search`
+2. Search Linkwarden bookmarks with `mcp__plugin_p-assist_linkwd__search_links`
 3. Correlate and present unified results
 4. Highlight connections and related content
 

--- a/plugins/01-p-assist/commands/journal-entry.md
+++ b/plugins/01-p-assist/commands/journal-entry.md
@@ -22,7 +22,7 @@ Create a new Logseq journal entry with the following content:
    - If it's a topic note, use a descriptive title from the content
    - Keep titles concise and searchable
 
-3. Use `mcp__logseq__create_page` to create the entry:
+3. Use `mcp__plugin_p-assist_logseq__create_page` to create the entry:
    - `title`: Generated page title
    - `content`: Formatted entry content
 

--- a/plugins/01-p-assist/commands/list-bookmarks.md
+++ b/plugins/01-p-assist/commands/list-bookmarks.md
@@ -19,12 +19,12 @@ List recent bookmarks from Linkwarden with intelligent filtering to prevent info
    - If neither: Show 8 most recent bookmarks across all collections
 
 2. **Handle collection filtering (if $1 provided):**
-   - Use `mcp__linkwd__get_all_collections` to list collections
+   - Use `mcp__plugin_p-assist_linkwd__get_all_collections` to list collections
    - Find collection ID matching "$1" (case-insensitive)
    - If collection doesn't exist, show available collections and suggest correct names
 
 3. **Fetch bookmarks with proper parameter defaults:**
-   - Use `mcp__linkwd__get_all_links` with these parameters:
+   - Use `mcp__plugin_p-assist_linkwd__get_all_links` with these parameters:
      - `collectionId`: Collection ID if filtering by collection, otherwise 0
      - `cursor: 0` - First page only (limits results to manageable amount)
      - `pinnedOnly: false` - Include all bookmarks

--- a/plugins/01-p-assist/commands/save-bookmark.md
+++ b/plugins/01-p-assist/commands/save-bookmark.md
@@ -14,13 +14,13 @@ Save the following bookmark to Linkwarden:
 **Instructions:**
 
 1. First, check if the collection exists:
-   - Use `mcp__linkwd__get_all_collections` to list collections
+   - Use `mcp__plugin_p-assist_linkwd__get_all_collections` to list collections
    - Find the collection ID matching "$3" (case-insensitive)
    - If collection doesn't exist, list available collections and ask user to choose
 
 2. Fetch the URL content briefly to generate a better name:
-   - **Primary**: Try `mcp__tavily__tavily_extract` to get page title and content
-   - **Fallback**: If Tavily fails with token limit error, use `mcp__jina__read_url`
+   - **Primary**: Try `mcp__plugin_shared-mcp_tavily__tavily_extract` to get page title and content
+   - **Fallback**: If Tavily fails with token limit error, use `mcp__plugin_shared-mcp_jina__read_url`
    - **Last resort**: If both fail, use the domain name as the bookmark name
    - Extract the page title from the content for the bookmark name
 
@@ -29,7 +29,7 @@ Save the following bookmark to Linkwarden:
    - Based on the URL domain or content type
    - Keep tags concise and relevant (2-4 tags)
 
-4. Save the bookmark using `mcp__linkwd__create_link`:
+4. Save the bookmark using `mcp__plugin_p-assist_linkwd__create_link`:
    - `url`: $1
    - `name`: Generated from page title
    - `description`: $2

--- a/plugins/01-p-assist/commands/search-journal.md
+++ b/plugins/01-p-assist/commands/search-journal.md
@@ -9,7 +9,7 @@ Search your Logseq journals for: "$ARGUMENTS"
 
 **Instructions:**
 
-1. Use `mcp__logseq__search` with the query: $ARGUMENTS
+1. Use `mcp__plugin_p-assist_logseq__search` with the query: $ARGUMENTS
 2. Set search parameters:
    - `include_pages: true` - to search page names
    - `include_blocks: true` - to search block content

--- a/plugins/01-p-assist/commands/summarize-article.md
+++ b/plugins/01-p-assist/commands/summarize-article.md
@@ -10,8 +10,8 @@ Fetch and summarize the article at: $1
 **Instructions:**
 
 1. Extract content from the URL using a two-tier approach:
-   - **Primary**: Try `mcp__tavily__tavily_extract` first (faster, works for most articles)
-   - **Fallback**: If Tavily fails with "exceeds maximum allowed tokens" error, use `mcp__jina__read_url`
+   - **Primary**: Try `mcp__plugin_shared-mcp_tavily__tavily_extract` first (faster, works for most articles)
+   - **Fallback**: If Tavily fails with "exceeds maximum allowed tokens" error, use `mcp__plugin_shared-mcp_jina__read_url`
    - Jina handles large content better and stays within token limits
 2. Analyze and create a comprehensive summary including:
    - Main topic and key points (3-5 bullet points)
@@ -22,7 +22,7 @@ Fetch and summarize the article at: $1
 **Optional Linkwarden Save:**
 
 If $2 equals "save":
-- Use `mcp__linkwd__create_link` to save the article to Linkwarden
+- Use `mcp__plugin_p-assist_linkwd__create_link` to save the article to Linkwarden
 - Use a descriptive name based on the article title
 - Add relevant tags based on the content
 - Include the summary in the description field

--- a/plugins/02-common-engineering/.claude-plugin/plugin.json
+++ b/plugins/02-common-engineering/.claude-plugin/plugin.json
@@ -4,19 +4,5 @@
   "version": "1.0.0",
   "author": {
     "name": "irfansofyana"
-  },
-  "mcpServers": {
-		"exa": {
-			"type": "stdio",
-			"command": "npx",
-			"args": [
-				"-y",
-				"mcp-remote",
-				"https://mcp.exa.ai/mcp?exaApiKey=${EXA_API_KEY}&tools=web_search_exa,get_code_context_exa,crawling_exa,company_research_exa,linkedin_search_exa,deep_researcher_start,deep_researcher_check"
-			],
-			"env": {
-				"EXA_API_KEY": "${EXA_API_KEY}"
-			}
-    	}
-	}
+  }
 }

--- a/plugins/02-common-engineering/README.md
+++ b/plugins/02-common-engineering/README.md
@@ -2,6 +2,18 @@
 
 A foundational plugin for Claude Code containing essential agents and skills for software engineers. This plugin provides common development utilities, diagram generation, documentation helpers, and other engineering tools to streamline your development workflow.
 
+## Prerequisites
+
+**Important**: This plugin requires the `shared-mcp` plugin to be installed first. The shared-mcp plugin provides the Exa MCP server used for web research and code context lookups.
+
+```bash
+# Install shared-mcp first
+/plugin install shared-mcp@my-claude-code-marketplace
+
+# Then install common-engineering
+/plugin install common-engineering@my-claude-code-marketplace
+```
+
 ## Overview
 
 The `common-engineering` plugin is designed as an extensible toolkit for software engineers, providing frequently-used capabilities as reusable agents and skills. Currently focused on professional diagram generation, this plugin will expand to include more engineering tools over time.
@@ -67,26 +79,18 @@ mmdc --version
 
 You should see output like: `10.6.1` or similar.
 
-#### Required for Web Research: Exa API Key
+#### Required for Web Research: shared-mcp Plugin
 
-The web research specialist uses Exa's powerful search capabilities for code research and general web search. You'll need an API key:
+The web research specialist uses Exa's powerful search capabilities from the `shared-mcp` plugin. Make sure you have:
 
-1. **Get your API key**: Visit [https://exa.ai](https://exa.ai) and sign up for an account
-2. **Set the environment variable**:
+1. **Installed the shared-mcp plugin**:
    ```bash
-   # Add to your shell profile (~/.zshrc, ~/.bashrc, or ~/.bash_profile)
-   export EXA_API_KEY="your-api-key-here"
-
-   # Reload your shell configuration
-   source ~/.zshrc  # or ~/.bashrc
+   /plugin install shared-mcp@my-claude-code-marketplace
    ```
 
-3. **Verify the variable is set**:
-   ```bash
-   echo $EXA_API_KEY
-   ```
+2. **Configured the EXA_API_KEY** as described in the [shared-mcp README](../00-shared-mcp/README.md)
 
-**Note**: Without the `EXA_API_KEY`, the web research specialist will fall back to using Claude's built-in WebSearch tool, which is less optimized for code research.
+**Note**: Without the `EXA_API_KEY` configured in shared-mcp, the web research specialist will fall back to using Claude's built-in WebSearch tool, which is less optimized for code research.
 
 ### Install the Plugin
 
@@ -205,7 +209,7 @@ Every diagram goes through a rigorous validation process:
 ### System Requirements
 - **Node.js**: Required for `mermaid-cli` (npm package)
 - **mermaid-cli**: The Mermaid command-line renderer
-- **EXA_API_KEY**: Environment variable for Exa search capabilities (optional but recommended)
+- **shared-mcp plugin**: Provides Exa MCP server for web research (optional but recommended)
 - **/tmp directory**: Used for validation temporary files
 
 ### Installation Verification
@@ -216,7 +220,7 @@ Test that everything is working:
 # 1. Check mermaid-cli installation
 mmdc --version
 
-# 2. Check Exa API key is set
+# 2. Check Exa API key is set (configured via shared-mcp plugin)
 echo $EXA_API_KEY
 
 # 3. Test the Mermaid agent by asking Claude:
@@ -287,14 +291,14 @@ npm install -g @mermaid-js/mermaid-cli
 
 **Solution:**
 ```bash
-# Check if EXA_API_KEY is set
+# 1. Ensure shared-mcp plugin is installed
+/plugin install shared-mcp@my-claude-code-marketplace
+
+# 2. Check if EXA_API_KEY is set
 echo $EXA_API_KEY
 
-# If not set, add it to your shell profile
-export EXA_API_KEY="your-api-key-here"
-source ~/.zshrc  # or ~/.bashrc
-
-# Restart Claude Code to pick up the new environment variable
+# 3. If not set, see shared-mcp README for configuration
+# Restart Claude Code after setting the environment variable
 ```
 
 #### 6. Exa API errors

--- a/plugins/02-common-engineering/agents/web-research-specialist.md
+++ b/plugins/02-common-engineering/agents/web-research-specialist.md
@@ -1,7 +1,7 @@
 ---
 name: web-research-specialist
 description: Expert web researcher for debugging, technical solutions, and comprehensive topic research across GitHub issues, Stack Overflow, Reddit, forums, and documentation. Use when users need to find solutions to technical problems, research implementation approaches, or gather information from multiple online sources. Particularly strong for code-related research and finding community solutions to library/framework issues.
-tools: Read, Grep, Glob, Bash, WebSearch, WebFetch, mcp__plugin_common-engineering_exa__web_search_exa, mcp__plugin_common-engineering_exa__get_code_context_exa
+tools: Read, Grep, Glob, Bash, WebSearch, WebFetch, mcp__plugin_shared-mcp_exa__web_search_exa, mcp__plugin_shared-mcp_exa__get_code_context_exa
 model: inherit
 color: blue
 ---
@@ -21,7 +21,7 @@ You are an expert internet researcher specializing in finding relevant informati
 **For ALL web research tasks, ALWAYS prefer Exa tools over built-in tools:**
 
 ### Primary Research Tools:
-1. **For Code/Programming/API Research**: **Use `mcp__plugin_common-engineering_exa__get_code_context_exa`**
+1. **For Code/Programming/API Research**: **Use `mcp__plugin_shared-mcp_exa__get_code_context_exa`**
    - API documentation and usage examples
    - Library/SDK implementation guides
    - Framework best practices
@@ -29,7 +29,7 @@ You are an expert internet researcher specializing in finding relevant informati
    - Programming language features
    - Any task involving code, libraries, or technical implementations
 
-2. **For General Web Research**: **Use `mcp__plugin_common-engineering_exa__web_search_exa`**
+2. **For General Web Research**: **Use `mcp__plugin_shared-mcp_exa__web_search_exa`**
    - Debugging issues and error solutions
    - Finding community discussions
    - Technical problem-solving
@@ -84,23 +84,23 @@ When presenting findings, you will:
 ## Research Execution
 
 ### 1. Always Start with Exa Tools
-- **For any search query**: First use `mcp__plugin_common-engineering_exa__web_search_exa`
-- **For code/API queries**: First use `mcp__plugin_common-engineering_exa__get_code_context_exa`
+- **For any search query**: First use `mcp__plugin_shared-mcp_exa__web_search_exa`
+- **For code/API queries**: First use `mcp__plugin_shared-mcp_exa__get_code_context_exa`
 - **Only after Exa fails**: Then try WebSearch as fallback
 
 ### 2. For Debugging Assistance
-- Use `mcp__plugin_common-engineering_exa__web_search_exa` to search for exact error messages in quotes
+- Use `mcp__plugin_shared-mcp_exa__web_search_exa` to search for exact error messages in quotes
 - Find workarounds and known solutions from community sources
 - Look for GitHub issues, Stack Overflow discussions, and forum posts
 - Check if it's a known bug with existing patches or PRs
 
 ### 3. For Comparative Research
-- Use `mcp__plugin_common-engineering_exa__web_search_exa` to find real-world usage examples and case studies
+- Use `mcp__plugin_shared-mcp_exa__web_search_exa` to find real-world usage examples and case studies
 - Look for performance benchmarks and user experiences from forums and discussions
 - Identify trade-offs and decision factors from multiple sources
 
 ### 4. For Code Research (SPECIALIZED)
-- **Always use `mcp__plugin_common-engineering_exa__get_code_context_exa`** as your primary tool for code-related queries
+- **Always use `mcp__plugin_shared-mcp_exa__get_code_context_exa`** as your primary tool for code-related queries
 - This provides the highest quality and freshest context for:
   - React, Vue, Angular, and other framework APIs
   - Python, JavaScript, Go, Rust library documentation


### PR DESCRIPTION
Summary
Extract shared MCP infrastructure into a new dedicated shared-mcp plugin (Tavily, Jina, Exa)
Add web-research-specialist agent to common-engineering plugin with intelligent tool selection
Refactor p-assist plugin to depend on shared-mcp instead of bundling its own MCP servers
Update documentation with plugin dependency information and installation order
Key Changes
New Plugin: shared-mcp (plugins/00-shared-mcp)
Centralizes common MCP servers: Tavily, Jina, Exa
Reduces configuration overhead (configure API keys once)
Enables MCP server sharing across plugins
Provides consistent tool naming
Updated: p-assist (plugins/01-p-assist)
Removed bundled MCP server configuration
Now depends on shared-mcp plugin for Tavily and Jina tools
Updated tool references throughout commands and agents
Updated: common-engineering (plugins/02-common-engineering)
Added web-research-specialist agent with Exa MCP integration
Prioritizes Exa tools over built-in WebSearch for technical research
Comprehensive documentation with EXA_API_KEY setup
Documentation Updates
Updated CLAUDE.md with plugin dependency graph
Added installation order instructions (shared-mcp first)