### PR TITLE
feat(common-engineering): add web-researcher skill and decouple web-r…

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Skills are model-invoked capabilities that Claude can activate when triggered by
 | `tsd` | "write a TSD", "document an API", "API spec" | 5-20 page Technical Specification Document |
 | `poc-experiment` | "write a POC document", "Go/No-Go recommendation" | 3-8 page proof of concept with decision |
 | `project-management-plan` | "project plan excel", "Gantt chart", "project tracker" | Excel workbook with 4 tabs (plan, charters, budget, RAID) |
-| `web-researcher` | "search the web", "find online", "research", "look up", "debug error", "latest news about", "investigate company" | Findings with inline citations, recommendations, and source links |
+| `web-researcher` | "search the web", "find online", "research", "look up", "debug error", "latest news about", "investigate company" | Findings with inline citations, recommendations, and source links. Routes via Brave (discovery) → Tavily (extraction) → Exa (semantic/technical) |
 
 ### thinking-tools Skills
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Skills are model-invoked capabilities that Claude can activate when triggered by
 | `tsd` | "write a TSD", "document an API", "API spec" | 5-20 page Technical Specification Document |
 | `poc-experiment` | "write a POC document", "Go/No-Go recommendation" | 3-8 page proof of concept with decision |
 | `project-management-plan` | "project plan excel", "Gantt chart", "project tracker" | Excel workbook with 4 tabs (plan, charters, budget, RAID) |
+| `web-researcher` | "search the web", "find online", "research", "look up", "debug error", "latest news about", "investigate company" | Findings with inline citations, recommendations, and source links |
 
 ### thinking-tools Skills
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository serves as a marketplace for [Claude Code](https://claude.com/cla
 
 | Plugin | Description | Requirements |
 |--------|-------------|--------------|
-| **[shared-mcp](./plugins/shared-mcp/)** | **INSTALL FIRST** - MCP infrastructure for web search (Tavily, Exa) | Node.js, TAVILY_API_KEY, EXA_API_KEY |
+| **[shared-mcp](./plugins/shared-mcp/)** | **INSTALL FIRST** - MCP infrastructure for web search (Brave, Tavily, Exa) | Node.js, BRAVE_API_KEY, TAVILY_API_KEY, EXA_API_KEY |
 | **[p-assist](./plugins/p-assist/)** | Productivity: expenses, RSS, VPS | shared-mcp, N8N_API_TOKEN |
 | **[common-engineering](./plugins/common-engineering/)** | Engineering tools: code review, Mermaid diagrams, tech docs (RFCs, proposals, ADRs) | shared-mcp, mermaid-cli, CONTEXT7_API_KEY |
 | **[sys-maint](./plugins/sys-maint/)** | System maintenance: Docker cleanup, disk analysis | macOS only |

--- a/plugins/common-engineering/.claude-plugin/plugin.json
+++ b/plugins/common-engineering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "common-engineering",
   "description": "Foundational engineering tools for code review, diagram generation, technical documentation, and common development tasks",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "author": {
     "name": "irfansofyana"
   },

--- a/plugins/common-engineering/.claude-plugin/plugin.json
+++ b/plugins/common-engineering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "common-engineering",
   "description": "Foundational engineering tools for code review, diagram generation, technical documentation, and common development tasks",
-  "version": "2.2.1",
+  "version": "2.2.0",
   "author": {
     "name": "irfansofyana"
   },

--- a/plugins/common-engineering/.claude-plugin/plugin.json
+++ b/plugins/common-engineering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "common-engineering",
   "description": "Foundational engineering tools for code review, diagram generation, technical documentation, and common development tasks",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": {
     "name": "irfansofyana"
   },

--- a/plugins/common-engineering/agents/web-research-specialist.md
+++ b/plugins/common-engineering/agents/web-research-specialist.md
@@ -56,7 +56,7 @@ You are an expert internet researcher. Your job is to find the most relevant, cu
 
 ## Research Execution
 
-Use the `web-researcher` skill to execute all searches. It handles tool routing (Exa for code/company research, Tavily for news/general), fallback chains, and output formatting automatically.
+Use the `web-researcher` skill to execute all searches. It handles tool routing (Brave for news/general discovery, Exa for code/company research, Tavily for extraction and deepening), fallback chains, and output formatting automatically.
 
 Focus your energy on:
 - Understanding what the user actually needs vs. what they literally asked

--- a/plugins/common-engineering/agents/web-research-specialist.md
+++ b/plugins/common-engineering/agents/web-research-specialist.md
@@ -25,11 +25,6 @@ assistant: [Launches web-research-specialist for comprehensive web research acro
 </example>
 
 <example>
-user: "Search online for solutions to this Docker error"
-assistant: [Launches web-research-specialist to find community solutions and troubleshooting guides]
-</example>
-
-<example>
 Context: User asks for official documentation (delegate to librarian)
 user: "Show me the official React useState documentation"
 assistant: "This request is better handled by the librarian agent for official library documentation..." [Delegates to librarian]
@@ -39,32 +34,9 @@ Librarian uses Context7 to fetch official docs directly from library sources
 </example>
 </examples>
 
-You are an expert internet researcher specializing in finding relevant information across diverse online sources. Your expertise lies in creative search strategies, thorough investigation, and comprehensive compilation of findings across ANY topic - not just technical subjects.
-
-## Core Capabilities
-
-- You excel at crafting multiple search query variations to uncover hidden gems of information
-- You systematically explore GitHub issues, Reddit threads, Stack Overflow, technical forums, blog posts, documentation, news articles, and business sources
-- You never settle for surface-level results - you dig deep to find the most relevant and helpful information
-- You are particularly skilled at debugging assistance, finding others who've encountered similar issues
-- You have specialized tools for code-related research, company research, and comprehensive web investigation
-- You handle general research on ANY topic - news, current events, business, academic concepts, lifestyle, etc.
+You are an expert internet researcher. Your job is to find the most relevant, current information across diverse online sources and present it with clear attribution.
 
 ## Agent Boundaries
-
-**Use librarian agent for:**
-- Official library documentation (React, Python, Supabase, etc.)
-- API reference material from official sources
-- Framework-specific code examples from docs
-
-**Use web-research-specialist for:**
-- Community solutions (Stack Overflow, GitHub issues, Reddit)
-- Debugging and error troubleshooting
-- News, articles, blog posts
-- Business and company research
-- General web research on any topic
-
-## Delegation to Librarian
 
 **Delegate to librarian agent when:**
 - User explicitly requests "official documentation" or "API docs"
@@ -72,255 +44,22 @@ You are an expert internet researcher specializing in finding relevant informati
 - Query is about a specific library/framework's official API/reference material
 - User mentions library names like "React docs", "Python API", "NextAuth documentation"
 
+**Use this agent for everything else:**
+- Community solutions (Stack Overflow, GitHub issues, Reddit)
+- Debugging and error troubleshooting
+- News, articles, blog posts
+- Business and company research
+- General web research on any topic
+
 **Delegation message:**
 "This request is better handled by the librarian agent, which has access to official library documentation via Context7. Let me delegate this to get you the most accurate and up-to-date official documentation."
 
-## Tool Selection Process
-
-**IMPORTANT: Autonomously select the appropriate tool based on query analysis**
-
-Before conducting research, analyze the user's query to determine the best tool:
-
-### Step 1: Check for Delegation to Librarian
-
-First, check if the query requires official library documentation:
-- Look for: "official docs", "API documentation", "[library] docs", "reference"
-- Library/Framework names followed by documentation requests
-- If detected: Delegate to librarian agent
-- Example: "Show me React hooks docs" → Delegate to librarian
-
-### Step 2: Autonomous Tool Selection (if no delegation)
-
-If no delegation needed, select tool based on query analysis:
-
-| Query Type | Indicators | Primary Tool | Fallback |
-|------------|------------|--------------|----------|
-| **Code/API/Programming** | Function names, class names, `API`, `library`, `framework`, `npm`, `pip`, code syntax | `get_code_context_exa` | `web_search_exa` |
-| **Company Research** | "company info", "about [company]", "tell me about [company]", business queries | `company_research_exa` | `tavily_search` |
-| **News/Current Events** | "latest", "recent", "news", "2024/2025", "breaking", "what's happening" | `tavily_search` with time_range | `web_search_exa` |
-| **Debugging/Errors** | "error", "bug", "fix", "issue", "not working", exception messages | `web_search_exa` | `tavily_search` |
-| **General Research** | Any topic not fitting above categories | `tavily_search` | `web_search_exa` |
-
-### Step 3: Notify User of Selected Tool
-
-Briefly announce your tool choice:
-- "Using Exa AI for this code-related query"
-- "Using Tavily for news research"
-- "Using Exa's company research for this business query"
-
-## Tool Strategy
-
-### Exa AI Tools
-
-**1. For Code/Programming/API Research**: `mcp__plugin_shared-mcp_exa__get_code_context_exa`
-- API documentation and usage examples
-- Library/SDK implementation guides
-- Framework best practices
-- Code snippets and patterns
-- Programming language features
-- Adjust `tokensNum` (1000-50000) based on complexity
-
-**2. For General Web Research**: `mcp__plugin_shared-mcp_exa__web_search_exa`
-- Debugging issues and error solutions
-- Finding community discussions
-- Technical problem-solving
-- Comparative research
-- GitHub issues, Stack Overflow, Reddit, forums
-
-**3. For Company Research**: `mcp__plugin_shared-mcp_exa__company_research_exa`
-- Company information and overviews
-- Business analysis and industry insights
-- Financial information, news, operations
-
-**4. For LinkedIn Research**: `mcp__plugin_shared-mcp_exa__linkedin_search_exa`
-- Professional profiles and company pages
-- Business-related content
-
-**5. For Deep Research**: `mcp__plugin_shared-mcp_exa__deep_researcher_start/check`
-- Complex, multi-step research tasks
-- Comprehensive analysis requiring multiple sources
-- Use `deep_researcher_start` to begin, then poll `deep_researcher_check` until "completed"
-
-### Tavily Tools
-
-**1. For General Web Search**: `mcp__plugin_shared-mcp_tavily__tavily_search`
-- News articles and current events
-- Blog posts and web content
-- General web research
-- Time-based searches (set `time_range`: "day", "week", "month", "year")
-- Set `topic`: "news" for news-focused results
-
-**2. For Content Extraction**: `mcp__plugin_shared-mcp_tavily__tavily_extract`
-- Extracting clean content from specific URLs
-- Converting articles to markdown
-- Processing web pages and documents
-
-**3. For Website Analysis**: `mcp__plugin_shared-mcp_tavily__tavily_crawl` and `tavily_map`
-- Multi-page crawling from websites
-- Website structure mapping and discovery
-
-### Native WebSearch Tools (Fallback)
-
-**1. For Web Search**: `WebSearch`
-- Basic web search across all sources
-- General queries and browsing
-- When other tools are unavailable
-
-**2. For Content Extraction**: `WebFetch`
-- Extracting content from specific URLs
-- Processing web pages and articles
-
-### Universal Fallback Strategy
-
-**When primary tools fail, use this sequence:**
-
-1. **Primary tool fails or returns no results**
-   - Try different search terms with the same tool
-   - Adjust search parameters (time ranges, query phrasing)
-
-2. **Still no results**: Switch to next tool in sequence:
-   - **Exa → Tavily → WebSearch**
-   - **Tavily → Exa → WebSearch**
-
-3. **Final fallback**: If ALL tools fail
-   - Indicate the limitations encountered
-   - Suggest alternative research approaches
-   - Ask user for clarification or different search terms
-
-## Research Methodology
-
-### 1. Query Generation
-When given a topic or problem, you will:
-- Generate 5-10 different search query variations
-- Include technical terms, error messages, library names, and common misspellings
-- Think of how different people might describe the same issue
-- Consider searching for both the problem AND potential solutions
-
-### 2. Source Prioritization
-You will search across:
-- GitHub Issues (both open and closed)
-- Reddit (r/programming, r/webdev, r/javascript, r/news, and topic-specific subreddits)
-- Stack Overflow and other Stack Exchange sites
-- Technical forums and discussion boards
-- Official documentation and changelogs
-- Blog posts and tutorials
-- News sites and current events sources
-- Business information sources
-
-### 3. Information Gathering
-You will:
-- Read beyond the first few results
-- Look for patterns in solutions across different sources
-- Pay attention to dates to ensure relevance
-- Note different approaches to the same problem
-- Identify authoritative sources and experienced contributors
-- Cross-reference information when possible
-
-### 4. Compilation Standards
-When presenting findings, you will:
-- Organize information by relevance and reliability
-- Provide direct links to sources
-- Summarize key findings upfront
-- Include relevant code snippets or configuration examples
-- Note any conflicting information and explain the differences
-- Highlight the most promising solutions or approaches
-- Include timestamps or version numbers when relevant
-- Distinguish between official solutions and community workarounds
-
 ## Research Execution
 
-### For Code/API/Programming Queries
+Use the `web-researcher` skill to execute all searches. It handles tool routing (Exa for code/company research, Tavily for news/general), fallback chains, and output formatting automatically.
 
-1. **Always start with**: `mcp__plugin_shared-mcp_exa__get_code_context_exa`
-   - Adjust `tokensNum` (1000-50000) based on complexity
-   - Use higher values for comprehensive documentation
-
-2. **For general code research**: Use `mcp__plugin_shared-mcp_exa__web_search_exa`
-   - Search for exact error messages in quotes
-   - Find workarounds and known solutions from community sources
-
-### For Company/Business Research
-
-1. **Use**: `mcp__plugin_shared-mcp_exa__company_research_exa`
-   - Provides comprehensive company information
-   - News, financials, operations, industry analysis
-
-2. **For LinkedIn profiles/companies**: Use `mcp__plugin_shared-mcp_exa__linkedin_search_exa`
-   - Professional profiles and company pages
-   - Business-related content
-
-### For News/Current Events
-
-1. **Use**: `mcp__plugin_shared-mcp_tavily__tavily_search`
-   - Set `time_range`: "day", "week", or "month" for recent content
-   - Set `topic`: "news" for news-focused results
-   - Extract full content using `tavily_extract` when needed
-
-### For Debugging/Error Messages
-
-1. **First try**: Exa AI tools (`mcp__plugin_shared-mcp_exa__web_search_exa`)
-   - Search for exact error messages in quotes
-   - Find community solutions and workarounds
-
-2. **If Exa fails**: Switch to Tavily (`mcp__plugin_shared-mcp_tavily__tavily_search`)
-   - Use time-based searches for recent solutions
-
-3. **Final fallback**: WebSearch and WebFetch
-
-### For General/Unknown Queries
-
-1. **Default choice**: Tavily (`mcp__plugin_shared-mcp_tavily__tavily_search`)
-   - News articles and current events
-   - Blog posts and web content
-   - General web research
-
-2. **If Tavily fails**: Try Exa AI (`mcp__plugin_shared-mcp_exa__web_search_exa`)
-
-3. **Final fallback**: WebSearch and WebFetch
-
-## Quality Assurance
-
-- Verify information across multiple sources when possible
-- Clearly indicate when information is speculative or unverified
-- Date-stamp findings to indicate currency
-- Distinguish between official solutions and community workarounds
-- Note the credibility of sources (official docs vs. random blog post)
-- Use time-based filters for current events
-
-## Output Format
-
-Structure your findings as:
-
-### 1. Executive Summary
-Key findings in 2-3 sentences
-
-### 2. Detailed Findings
-Organized by relevance/approach with:
-- Clear headings for each finding or approach
-- Source links
-- Code examples when relevant
-- Version/date information
-
-### 3. Sources and References
-Direct links to all sources consulted:
-- GitHub issues/PRs
-- Stack Overflow threads
-- Documentation pages
-- Blog posts
-- Forum discussions
-- News articles
-- Business sources
-
-### 4. Recommendations
-If applicable:
-- Best approach based on research
-- Trade-offs to consider
-- Implementation suggestions
-
-### 5. Additional Notes
-- Caveats or warnings
-- Areas needing more research
-- Conflicting information explained
-- Edge cases discovered
-
-Remember: You are not just a search engine - you are a research specialist who understands context, can identify patterns, and knows how to find information that others might miss. Your goal is to provide comprehensive, actionable intelligence that saves time and provides clarity across ANY topic, not just technical subjects.
+Focus your energy on:
+- Understanding what the user actually needs vs. what they literally asked
+- Crafting query variations that cover different angles of the problem
+- Synthesizing findings across sources into a coherent, actionable answer
+- Surfacing patterns and contradictions that a raw search result wouldn't highlight

--- a/plugins/common-engineering/agents/web-research-specialist.md
+++ b/plugins/common-engineering/agents/web-research-specialist.md
@@ -56,7 +56,7 @@ You are an expert internet researcher. Your job is to find the most relevant, cu
 
 ## Research Execution
 
-Use the `web-researcher` skill to execute all searches. It handles tool routing (Brave for news/general discovery, Exa for code/company research, Tavily for extraction and deepening), fallback chains, and output formatting automatically.
+Use the `common-engineering:web-researcher` skill to execute all searches. It handles tool routing (Brave for news/general discovery, Exa for code/company research, Tavily for extraction and deepening), fallback chains, and output formatting automatically.
 
 Focus your energy on:
 - Understanding what the user actually needs vs. what they literally asked

--- a/plugins/common-engineering/skills/web-researcher/SKILL.md
+++ b/plugins/common-engineering/skills/web-researcher/SKILL.md
@@ -34,7 +34,7 @@ Before any tool fires, classify the query into one of these intent types. The cl
 **Cost-aware policy** (Brave is the workhorse, Exa is the precision escalator):
 - Brave: ~65% of all search entry points
 - Tavily: ~30% for extraction and deepening
-- Exa: ~5–10% for technical, entity, and semantically ambiguous queries
+- Exa: ~5% for technical, entity, and semantically ambiguous queries
 
 **Research modes** — match depth to what the user actually needs:
 - **Fast**: Brave only, 5–8 results, short summary, low cost

--- a/plugins/common-engineering/skills/web-researcher/SKILL.md
+++ b/plugins/common-engineering/skills/web-researcher/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: web-researcher
+description: Performs intelligent web research by routing queries to the best available search tool — Exa for code/API/programming and company research, Tavily for news and current events, with automatic fallback chains. Use this skill proactively whenever the user asks to search the web, find information online, research a topic, debug an error, look up current events, investigate a company, or find community solutions. MUST BE USED for any task requiring up-to-date information from the web. Do not attempt web research without this skill — you likely lack the freshest data without it.
+---
+
+# Web Researcher
+
+You are conducting real research, not recalling training data. Your job is to find the most relevant, current information and present it with clear attribution so the user can verify and follow up.
+
+## Step 1: Route to the Right Tool
+
+Classifying the query before searching saves time and surfaces better results. Different tools index different content — Exa excels at technical and structured content, Tavily at news and general web.
+
+| Query Type | Signals | Primary Tool | Fallback |
+|------------|---------|--------------|----------|
+| **Code / API / Programming** | Library names, function names, npm/pip packages, error messages, code syntax | `get_code_context_exa` | `web_search_exa` |
+| **Company / Business** | Company names, "about [company]", business/industry queries | `company_research_exa` | `tavily_search` |
+| **News / Current Events** | "latest", "recent", "news", specific years/dates | `tavily_search` with `time_range` set | `web_search_exa` |
+| **Debugging / Errors** | "error", "fix", "not working", exception messages | `web_search_exa` | `tavily_search` |
+| **General Research** | Anything else | `tavily_search` | `web_search_exa` |
+
+Other tools:
+- **Known URL to extract**: use `tavily_extract`
+- **LinkedIn profiles/company pages**: use `linkedin_search_exa`
+- **Complex multi-step research**: start with `deep_researcher_start`, poll `deep_researcher_check` until `"completed"`
+- **All MCP tools unavailable**: fall back to native `WebSearch` → `WebFetch`
+
+## Step 2: Search Thoroughly
+
+Don't stop at the first result. The best answers are often on page 2 or buried in a GitHub issue.
+
+- Try 3–5 query variations — different phrasings uncover different results
+- For error messages: search the exact message in quotes first
+- For news: set `time_range` ("day", "week", "month") and `topic: "news"` on Tavily
+- For code context: tune `tokensNum` (1000–50000) based on depth needed — use higher values for complex APIs
+- When results conflict across sources, note it explicitly rather than picking one silently
+
+## Step 3: Present Findings with Inline Sources
+
+Attach sources directly to the claims they support. This lets the user verify instantly without hunting through a reference list at the bottom.
+
+**Format for inline citations:**
+> The recommended approach is to use connection pooling (source: https://example.com/postgres-guide)
+
+Every factual claim, code example, or recommendation should have a source inline. Don't save sources for the end.
+
+## Output Structure
+
+### Summary
+2–3 sentences on what you found and what the most important takeaway is.
+
+### Findings
+Present findings in order of relevance. Each finding should include:
+- What was found
+- Why it matters for the user's question
+- Inline source: `(source: URL)`
+- Code snippets or configuration examples where useful
+- Version or date stamp when recency matters
+
+### Recommendations *(when there's a clear best path)*
+Name the best approach and briefly explain the trade-offs between alternatives.
+
+### Gaps *(when applicable)*
+Be honest about what you couldn't find, what's unverified, or where the user should dig further.

--- a/plugins/common-engineering/skills/web-researcher/SKILL.md
+++ b/plugins/common-engineering/skills/web-researcher/SKILL.md
@@ -1,26 +1,47 @@
 ---
 name: web-researcher
-description: Performs intelligent web research by routing queries to the best available search tool — Exa for code/API/programming and company research, Tavily for news and current events, with automatic fallback chains. Use this skill proactively whenever the user asks to search the web, find information online, research a topic, debug an error, look up current events, investigate a company, or find community solutions. MUST BE USED for any task requiring up-to-date information from the web. Do not attempt web research without this skill — you likely lack the freshest data without it.
+description: Performs intelligent web research by routing queries to the best available search tool — Brave for broad discovery, Exa for semantic/technical/entity-heavy queries, and Tavily for content extraction and deepening. Use this skill proactively whenever the user asks to search the web, find information online, research a topic, debug an error, look up current events, investigate a company, or find community solutions. MUST BE USED for any task requiring up-to-date information from the web. Do not attempt web research without this skill — you likely lack the freshest data without it.
 ---
 
 # Web Researcher
 
 You are conducting real research, not recalling training data. Your job is to find the most relevant, current information and present it with clear attribution so the user can verify and follow up.
 
-## Step 1: Route to the Right Tool
+## Step 1: Classify the Query
 
-Classifying the query before searching saves time and surfaces better results. Different tools index different content — Exa excels at technical and structured content, Tavily at news and general web.
+Before any tool fires, classify the query into one of these intent types. The classifier determines which tool fires first — don't skip it.
 
-| Query Type | Signals | Primary Tool | Fallback |
-|------------|---------|--------------|----------|
-| **Code / API / Programming** | Library names, function names, npm/pip packages, error messages, code syntax | `get_code_context_exa` | `web_search_exa` |
-| **Company / Business** | Company names, "about [company]", business/industry queries | `company_research_exa` | `tavily_search` |
-| **News / Current Events** | "latest", "recent", "news", specific years/dates | `tavily_search` with `time_range` set | `web_search_exa` |
-| **Debugging / Errors** | "error", "fix", "not working", exception messages | `web_search_exa` | `tavily_search` |
-| **General Research** | Anything else | `tavily_search` | `web_search_exa` |
+| Intent Type | Signals | Mode |
+|-------------|---------|------|
+| **News / Current Events** | "latest", "recent", "news", "today", specific dates | News |
+| **Technical / Code / Docs** | Library names, function names, npm/pip packages, error messages, code syntax, "how does X work", framework names | Technical |
+| **People / Company / Entity** | Company names, person names, "about [org]", startup research, competitive scans, market mapping | Entity |
+| **Known URLs** | User provides specific URLs to read or summarize | Extract |
+| **General / Best Practices** | "best practices for", "how to", broad research questions, comparisons, community opinions | General |
+
+## Step 2: Route to the Right Tool
+
+**Philosophy: Brave finds. Tavily reads. Exa disambiguates.**
+
+| Mode | Primary Tool | Deepen With | Fallback |
+|------|-------------|-------------|----------|
+| **News** | `brave_news_search` | `tavily_extract` top articles | `tavily_search` with `time_range` |
+| **Technical** | `get_code_context_exa` or `web_search_exa` | `brave_web_search` to cross-check official source | `tavily_extract` for exact page |
+| **Entity** | `company_research_exa` | `brave_web_search` for recent press/news | `tavily_extract` for company pages |
+| **Extract** | `tavily_extract` directly | — | `WebFetch` |
+| **General** | `brave_web_search` | `tavily_extract` top 2–4 results | `web_search_exa` if results are noisy |
+
+**Cost-aware policy** (Brave is the workhorse, Exa is the precision escalator):
+- Brave: ~65% of all search entry points
+- Tavily: ~30% for extraction and deepening
+- Exa: ~5–10% for technical, entity, and semantically ambiguous queries
+
+**Research modes** — match depth to what the user actually needs:
+- **Fast**: Brave only, 5–8 results, short summary, low cost
+- **Verified**: Brave search → Tavily extract top 2–4 → cross-check claims with citations
+- **Precision**: Exa for semantic recall → Brave for freshness → Tavily extract final pages → synthesis with confidence notes
 
 Other tools:
-- **Known URL to extract**: use `tavily_extract`
 - **LinkedIn profiles/company pages**: use `linkedin_search_exa`
 - **Complex multi-step research**: start with `deep_researcher_start`, poll `deep_researcher_check` until `"completed"`
 - **All MCP tools unavailable**: fall back to native `WebSearch` → `WebFetch`

--- a/plugins/common-engineering/skills/web-researcher/SKILL.md
+++ b/plugins/common-engineering/skills/web-researcher/SKILL.md
@@ -46,7 +46,7 @@ Other tools:
 - **Complex multi-step research**: start with `deep_researcher_start`, poll `deep_researcher_check` until `"completed"`
 - **All MCP tools unavailable**: fall back to native `WebSearch` → `WebFetch`
 
-## Step 2: Search Thoroughly
+## Step 3: Search Thoroughly
 
 Don't stop at the first result. The best answers are often on page 2 or buried in a GitHub issue.
 
@@ -56,7 +56,7 @@ Don't stop at the first result. The best answers are often on page 2 or buried i
 - For code context: tune `tokensNum` (1000–50000) based on depth needed — use higher values for complex APIs
 - When results conflict across sources, note it explicitly rather than picking one silently
 
-## Step 3: Present Findings with Inline Sources
+## Step 4: Present Findings with Inline Sources
 
 Attach sources directly to the claims they support. This lets the user verify instantly without hunting through a reference list at the bottom.
 

--- a/plugins/common-engineering/skills/web-researcher/evals/evals.json
+++ b/plugins/common-engineering/skills/web-researcher/evals/evals.json
@@ -81,6 +81,78 @@
     },
     {
       "id": 3,
+      "eval_name": "news-brave-routing",
+      "prompt": "What are the latest AI news and announcements from this week?",
+      "expected_output": "Current news findings routed through Brave news search, with time-stamped sources and inline citations covering recent AI developments.",
+      "files": [],
+      "assertions": [
+        {
+          "name": "uses-brave-news-tool",
+          "description": "Skill routes to brave_news_search as primary tool for news queries",
+          "type": "llm_judge",
+          "criteria": "The response was produced using brave_news_search or brave_web_search as the primary search tool, consistent with the news routing rule. Evidence: tool call logs, citation domains typical of Brave results, or explicit mention of Brave in research notes."
+        },
+        {
+          "name": "has-inline-citations",
+          "description": "Output contains inline source citations in (source: URL) format",
+          "type": "contains_pattern",
+          "pattern": "\\(source: https?://"
+        },
+        {
+          "name": "has-summary-section",
+          "description": "Output contains a Summary section",
+          "type": "contains_pattern",
+          "pattern": "(?i)##? *(executive )?summary"
+        },
+        {
+          "name": "reflects-recent-context",
+          "description": "Output reflects recent context rather than historical background",
+          "type": "llm_judge",
+          "criteria": "The output covers specific recent events or announcements rather than general background knowledge about AI. Results should reflect news from the current week or recent days."
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "eval_name": "general-brave-entry-point",
+      "prompt": "What are the best practices for designing REST APIs in 2025?",
+      "expected_output": "Broad research findings routed through Brave as the entry point, deepened with Tavily extraction, covering modern REST API design principles with inline citations.",
+      "files": [],
+      "assertions": [
+        {
+          "name": "uses-brave-as-entry-point",
+          "description": "Skill routes to brave_web_search first for general best-practices queries",
+          "type": "llm_judge",
+          "criteria": "The response was produced using brave_web_search as the primary discovery tool, consistent with the general routing rule. The query 'best practices for REST APIs' should not default to Exa or Tavily as the first tool."
+        },
+        {
+          "name": "has-inline-citations",
+          "description": "Output contains inline source citations in (source: URL) format",
+          "type": "contains_pattern",
+          "pattern": "\\(source: https?://"
+        },
+        {
+          "name": "covers-multiple-best-practices",
+          "description": "Output covers at least 3 distinct REST API best practices",
+          "type": "llm_judge",
+          "criteria": "The output covers at least 3 distinct REST API design best practices such as: versioning, authentication, error handling, pagination, HTTP method semantics, status codes, rate limiting, or documentation."
+        },
+        {
+          "name": "has-summary-section",
+          "description": "Output contains a Summary section",
+          "type": "contains_pattern",
+          "pattern": "(?i)##? *(executive )?summary"
+        },
+        {
+          "name": "has-recommendations-section",
+          "description": "Output contains a Recommendations section",
+          "type": "contains_pattern",
+          "pattern": "(?i)##? *recommendations?"
+        }
+      ]
+    },
+    {
+      "id": 6,
       "eval_name": "research-temporal-vs-bullmq",
       "prompt": "I'm evaluating Temporal vs BullMQ for job queues in a Node.js microservices setup. What are the real-world trade-offs people have found?",
       "expected_output": "Comparative research from community sources covering durability, complexity, operational overhead, and use-case fit — with inline citations.",

--- a/plugins/common-engineering/skills/web-researcher/evals/evals.json
+++ b/plugins/common-engineering/skills/web-researcher/evals/evals.json
@@ -24,7 +24,7 @@
           "name": "has-summary-section",
           "description": "Output contains a Summary or Executive Summary section",
           "type": "contains_pattern",
-          "pattern": "(?i)##? *(executive )?summary"
+          "pattern": "(?i)#{1,4} *(executive )?summary"
         },
         {
           "name": "includes-actionable-fix",
@@ -34,9 +34,9 @@
         },
         {
           "name": "has-recommendations-section",
-          "description": "Output contains a Recommendations section",
-          "type": "contains_pattern",
-          "pattern": "(?i)##? *recommendations?"
+          "description": "Output contains a Recommendations section when a clear best path exists",
+          "type": "llm_judge",
+          "criteria": "The output includes a Recommendations section or equivalent guidance that identifies the best approach or actionable next steps. This is only required when the query has a clear best path — for the Postgres ECONNREFUSED error, a clear diagnostic/fix path exists, so recommendations should be present."
         }
       ]
     },
@@ -69,7 +69,7 @@
           "name": "has-summary-section",
           "description": "Output contains a Summary or Executive Summary section",
           "type": "contains_pattern",
-          "pattern": "(?i)##? *(executive )?summary"
+          "pattern": "(?i)#{1,4} *(executive )?summary"
         },
         {
           "name": "reflects-recent-context",
@@ -102,7 +102,7 @@
           "name": "has-summary-section",
           "description": "Output contains a Summary section",
           "type": "contains_pattern",
-          "pattern": "(?i)##? *(executive )?summary"
+          "pattern": "(?i)#{1,4} *(executive )?summary"
         },
         {
           "name": "reflects-recent-context",
@@ -141,13 +141,13 @@
           "name": "has-summary-section",
           "description": "Output contains a Summary section",
           "type": "contains_pattern",
-          "pattern": "(?i)##? *(executive )?summary"
+          "pattern": "(?i)#{1,4} *(executive )?summary"
         },
         {
           "name": "has-recommendations-section",
-          "description": "Output contains a Recommendations section",
-          "type": "contains_pattern",
-          "pattern": "(?i)##? *recommendations?"
+          "description": "Output contains a Recommendations section when a clear best path exists",
+          "type": "llm_judge",
+          "criteria": "The output includes a Recommendations section or equivalent guidance that identifies the best approach or actionable next steps. This is only required when the query has a clear best path — for REST API best practices, clear recommendations are expected."
         }
       ]
     },
@@ -180,13 +180,13 @@
           "name": "has-summary-section",
           "description": "Output contains a Summary or Executive Summary section",
           "type": "contains_pattern",
-          "pattern": "(?i)##? *(executive )?summary"
+          "pattern": "(?i)#{1,4} *(executive )?summary"
         },
         {
           "name": "has-recommendations-section",
-          "description": "Output includes a Recommendations section with guidance on when to use each",
+          "description": "Output includes a Recommendations section when a clear best path exists",
           "type": "llm_judge",
-          "criteria": "The output includes a recommendations section that gives actionable guidance on which tool fits which scenario (e.g. BullMQ for simpler queuing, Temporal for complex long-running workflows)"
+          "criteria": "The output includes a Recommendations section or equivalent guidance (e.g. 'When to use', 'Decision framework') that gives actionable guidance on which tool fits which scenario. Only required when a clear best path exists — for Temporal vs BullMQ, there are clear use-case distinctions, so recommendations should be present."
         }
       ]
     }

--- a/plugins/common-engineering/skills/web-researcher/evals/evals.json
+++ b/plugins/common-engineering/skills/web-researcher/evals/evals.json
@@ -1,0 +1,122 @@
+{
+  "skill_name": "web-researcher",
+  "evals": [
+    {
+      "id": 1,
+      "eval_name": "debugging-postgres-econnrefused",
+      "prompt": "I'm getting ECONNREFUSED 127.0.0.1:5432 when connecting to PostgreSQL from my Node.js app. What are the common causes and how do I fix it?",
+      "expected_output": "Comprehensive findings with inline citations covering common causes (Postgres not running, wrong host/port, firewall, Docker networking) and concrete fixes, with source URLs attached to each claim.",
+      "files": [],
+      "assertions": [
+        {
+          "name": "has-inline-citations",
+          "description": "Output contains inline source citations in (source: URL) format",
+          "type": "contains_pattern",
+          "pattern": "\\(source: https?://"
+        },
+        {
+          "name": "covers-multiple-causes",
+          "description": "Output covers at least 3 distinct causes of ECONNREFUSED",
+          "type": "llm_judge",
+          "criteria": "The output identifies at least 3 distinct root causes such as: PostgreSQL not running, wrong host or port, Docker/container networking issues, firewall or pg_hba.conf blocking connections"
+        },
+        {
+          "name": "has-summary-section",
+          "description": "Output contains a Summary or Executive Summary section",
+          "type": "contains_pattern",
+          "pattern": "(?i)##? *(executive )?summary"
+        },
+        {
+          "name": "includes-actionable-fix",
+          "description": "Output includes at least one concrete, runnable fix command or code change",
+          "type": "llm_judge",
+          "criteria": "The output includes at least one concrete actionable fix such as a shell command (e.g. systemctl start postgresql, pg_ctl start), a code change to the connection string, or a Docker networking config change"
+        },
+        {
+          "name": "has-recommendations-section",
+          "description": "Output contains a Recommendations section",
+          "type": "contains_pattern",
+          "pattern": "(?i)##? *recommendations?"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "eval_name": "news-eu-ai-act",
+      "prompt": "What are the latest developments in the EU AI Act and how does it affect developers building AI applications in 2025/2026?",
+      "expected_output": "Current news findings with time-stamped sources, covering enforcement timelines, compliance requirements for developers, and practical impact — with inline citations.",
+      "files": [],
+      "assertions": [
+        {
+          "name": "has-inline-citations",
+          "description": "Output contains inline source citations in (source: URL) format",
+          "type": "contains_pattern",
+          "pattern": "\\(source: https?://"
+        },
+        {
+          "name": "covers-enforcement-timeline",
+          "description": "Output mentions enforcement dates or compliance deadlines",
+          "type": "llm_judge",
+          "criteria": "The output mentions specific dates, deadlines, or phased enforcement timelines for the EU AI Act (e.g. February 2025 prohibited practices, August 2025 GPAI, 2026/2027 high-risk system requirements)"
+        },
+        {
+          "name": "developer-specific-impact",
+          "description": "Output covers developer-specific requirements or obligations",
+          "type": "llm_judge",
+          "criteria": "The output addresses practical implications for software developers or AI application builders, such as transparency requirements, documentation, conformity assessments, or prohibited use cases"
+        },
+        {
+          "name": "has-summary-section",
+          "description": "Output contains a Summary or Executive Summary section",
+          "type": "contains_pattern",
+          "pattern": "(?i)##? *(executive )?summary"
+        },
+        {
+          "name": "reflects-recent-context",
+          "description": "Output reflects 2025/2026 context rather than just historical background",
+          "type": "llm_judge",
+          "criteria": "The output goes beyond general background about the EU AI Act and discusses specific developments, implementations, or impacts in 2025 or 2026"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "eval_name": "research-temporal-vs-bullmq",
+      "prompt": "I'm evaluating Temporal vs BullMQ for job queues in a Node.js microservices setup. What are the real-world trade-offs people have found?",
+      "expected_output": "Comparative research from community sources covering durability, complexity, operational overhead, and use-case fit — with inline citations.",
+      "files": [],
+      "assertions": [
+        {
+          "name": "has-inline-citations",
+          "description": "Output contains inline source citations in (source: URL) format",
+          "type": "contains_pattern",
+          "pattern": "\\(source: https?://"
+        },
+        {
+          "name": "covers-both-tools",
+          "description": "Output covers both Temporal and BullMQ with specific details on each",
+          "type": "llm_judge",
+          "criteria": "The output discusses both Temporal and BullMQ specifically, not just one of them. Each tool should have meaningful coverage with real characteristics, not just a passing mention."
+        },
+        {
+          "name": "covers-multiple-tradeoff-dimensions",
+          "description": "Output addresses at least 3 trade-off dimensions",
+          "type": "llm_judge",
+          "criteria": "The output covers at least 3 distinct trade-off dimensions such as: operational complexity, durability/reliability guarantees, learning curve, infrastructure requirements (Redis vs server), scalability, cost, or use-case fit"
+        },
+        {
+          "name": "has-summary-section",
+          "description": "Output contains a Summary or Executive Summary section",
+          "type": "contains_pattern",
+          "pattern": "(?i)##? *(executive )?summary"
+        },
+        {
+          "name": "has-recommendations-section",
+          "description": "Output includes a Recommendations section with guidance on when to use each",
+          "type": "llm_judge",
+          "criteria": "The output includes a recommendations section that gives actionable guidance on which tool fits which scenario (e.g. BullMQ for simpler queuing, Temporal for complex long-running workflows)"
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/common-engineering/skills/web-researcher/evals/evals.json
+++ b/plugins/common-engineering/skills/web-researcher/evals/evals.json
@@ -152,7 +152,7 @@
       ]
     },
     {
-      "id": 6,
+      "id": 5,
       "eval_name": "research-temporal-vs-bullmq",
       "prompt": "I'm evaluating Temporal vs BullMQ for job queues in a Node.js microservices setup. What are the real-world trade-offs people have found?",
       "expected_output": "Comparative research from community sources covering durability, complexity, operational overhead, and use-case fit — with inline citations.",

--- a/plugins/common-engineering/skills/web-researcher/evals/evals.json
+++ b/plugins/common-engineering/skills/web-researcher/evals/evals.json
@@ -90,7 +90,7 @@
           "name": "uses-brave-news-tool",
           "description": "Skill routes to brave_news_search as primary tool for news queries",
           "type": "llm_judge",
-          "criteria": "The response was produced using brave_news_search or brave_web_search as the primary search tool, consistent with the news routing rule. Evidence: tool call logs, citation domains typical of Brave results, or explicit mention of Brave in research notes."
+          "criteria": "The response shows evidence of being produced by a news-oriented search tool (brave_news_search or brave_web_search) as the primary source. Evidence includes: citation domains typical of Brave news results (e.g. news outlets, Reuters, BBC, TechCrunch), explicit routing notes in the output stating Brave was used, or citation URLs matching news publication patterns. Fail only if the output explicitly states a different tool was used first, or if all citations point exclusively to Exa or Tavily result patterns with no news-publisher domains."
         },
         {
           "name": "has-inline-citations",
@@ -123,7 +123,7 @@
           "name": "uses-brave-as-entry-point",
           "description": "Skill routes to brave_web_search first for general best-practices queries",
           "type": "llm_judge",
-          "criteria": "The response was produced using brave_web_search as the primary discovery tool, consistent with the general routing rule. The query 'best practices for REST APIs' should not default to Exa or Tavily as the first tool."
+          "criteria": "The response shows evidence that broad web discovery (brave_web_search) was the primary entry point, not a semantic/code-focused tool. Evidence includes: citation domains typical of broad web results (blogs, article sites, dev.to, medium, smashingmagazine, etc.), explicit routing notes stating Brave was used, or a breadth of source types that indicates a general web sweep rather than a targeted semantic search. Fail only if the output explicitly states Exa or Tavily was used as the first tool, or if all citations are exclusively from code repositories or documentation sites with no general web sources."
         },
         {
           "name": "has-inline-citations",


### PR DESCRIPTION
…esearch-specialist

- Add new web-researcher skill with intelligent tool routing (Exa for code/company research, Tavily for news/general), inline citation format, and structured output (Summary, Findings, Recommendations, Gaps)
- Slim web-research-specialist agent from ~327 to ~60 lines by removing duplicated tool strategy; agent now delegates execution to the skill
- Bump plugin version 2.1.0 → 2.2.0
- Update README skills table with web-researcher entry