### PR TITLE
feat(shared-mcp): add Brave Search MCP server

### DIFF
--- a/plugins/shared-mcp/.claude-plugin/plugin.json
+++ b/plugins/shared-mcp/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "shared-mcp",
 	"description": "Shared MCP infrastructure providing common web search, content extraction, and research tools for other plugins",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"author": {
 		"name": "irfansofyana"
 	},
@@ -28,6 +28,19 @@
 			],
 			"env": {
 				"EXA_API_KEY": "${EXA_API_KEY}"
+			}
+		},
+		"brave-search": {
+			"type": "stdio",
+			"command": "npx",
+			"args": [
+				"-y",
+				"@brave/brave-search-mcp-server",
+				"--transport",
+				"stdio"
+			],
+			"env": {
+				"BRAVE_API_KEY": "${BRAVE_API_KEY}"
 			}
 		}
 	}

--- a/plugins/shared-mcp/README.md
+++ b/plugins/shared-mcp/README.md
@@ -20,6 +20,7 @@ This plugin consolidates commonly-used MCP servers to:
 |--------|---------|----------------|-----------------|
 | **Tavily** | Web search and content extraction | `tavily_search`, `tavily_extract`, `tavily_crawl`, `tavily_map` | stdio/npx |
 | **Exa** | AI-powered web search and code context | `web_search_exa`, `get_code_context_exa`, `crawling_exa`, `deep_researcher_start/check` | stdio/npx |
+| **Brave Search** | Privacy-focused web search with local business, image, video, and news search | `brave_web_search`, `brave_local_search`, `brave_image_search`, `brave_video_search`, `brave_news_search`, `brave_summarizer` | stdio/npx |
 
 ## Installation
 
@@ -44,6 +45,9 @@ export TAVILY_API_KEY="your-tavily-api-key"
 
 # Exa API Key (https://exa.ai - free tier available)
 export EXA_API_KEY="your-exa-api-key"
+
+# Brave Search API Key (https://brave.com/search/api - free tier available)
+export BRAVE_API_KEY="your-brave-api-key"
 ```
 
 **After adding**, reload your shell configuration:
@@ -59,11 +63,13 @@ source ~/.bashrc
 ```bash
 echo $TAVILY_API_KEY  # Should display your API key
 echo $EXA_API_KEY
+echo $BRAVE_API_KEY
 ```
 
 **Getting API Keys:**
 - **Tavily**: Sign up at [tavily.com](https://tavily.com) - Free tier available
 - **Exa**: Sign up at [exa.ai](https://exa.ai) - Free tier available
+- **Brave Search**: Sign up at [brave.com/search/api](https://brave.com/search/api) - Free tier available
 
 ## Tool Name Format
 
@@ -116,3 +122,4 @@ Ensure the plugin is installed and enabled:
 - **1.1.0**: Updated Jina MCP to use direct SSE connection instead of stdio/npx (November 2025)
 - **1.2.0**: Updated Jina MCP endpoint from `/sse` to `/v1` with Streamable HTTP transport (December 2025)
 - **1.3.0**: Removed Jina MCP server (December 2025)
+- **1.4.0**: Added Brave Search MCP server for privacy-focused web search (April 2026)


### PR DESCRIPTION
## Summary

Add official Brave Search MCP server (`@brave/brave-search-mcp-server`) to the shared-mcp plugin.

## Changes

- **plugin.json**: Added `brave-search` MCP server configuration with stdio transport
- **Version bump**: 1.3.0 → 1.4.0
- **READMEs**: Updated root and plugin READMEs with Brave Search documentation and `BRAVE_API_KEY` configuration

## Tools Added

| Tool | Purpose |
|------|---------|
| `brave_web_search` | Comprehensive web search |
| `brave_local_search` | Local business/place search |
| `brave_image_search` | Image search |
| `brave_video_search` | Video search |
| `brave_news_search` | News search |
| `brave_summarizer` | AI-powered result summaries |

## Requirements

Users need to add `BRAVE_API_KEY` to their shell config:
```bash
export BRAVE_API_KEY="your-brave-api-key"  # https://brave.com/search/api
```

## Testing

- [ ] Plugin installs successfully
- [ ] Brave Search MCP server starts without errors
- [ ] All 6 tools are available in Claude Code