### PR TITLE
[codex] Improve decision-sparring skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository serves as a marketplace for reusable agent workflows across agen
 | **[p-assist](./plugins/p-assist/)** | Productivity: expenses, RSS, VPS | shared-mcp, N8N_API_TOKEN |
 | **[common-engineering](./plugins/common-engineering/)** | Engineering tools: code review, Mermaid diagrams, tech docs (RFCs, proposals, ADRs) | shared-mcp, mermaid-cli, CONTEXT7_API_KEY |
 | **[sys-maint](./plugins/sys-maint/)** | System maintenance: Docker cleanup, disk analysis | macOS only |
-| **[thinking-tools](./plugins/thinking-tools/)** | Thinking tools: pressure-test ideas (idea-refinery) and drill into execution plans (grill-me) | None |
+| **[thinking-tools](./plugins/thinking-tools/)** | Thinking tools: pressure-test ideas (idea-refinery) and resolve decision branches (decision-sparring) | None |
 | **[softskills](./plugins/softskills/)** | Office politics coach for navigating workplace dynamics | None |
 
 See individual plugin READMEs for detailed setup instructions.
@@ -42,7 +42,7 @@ Skills are model-invoked capabilities that agent runtimes can activate when trig
 | Skill | Trigger Phrases | Output |
 |-------|-----------------|--------|
 | `idea-refinery` | "pressure-test my idea", "sparring partner", "gut-check this idea", "is this worth doing" | Concise Idea Brief with problem, MVP, risks, next actions |
-| `grill-me` | "grill me", "interrogate my idea/plan", "stress-test this", "drill into this", "poke holes in it", "help me think through whether to pursue this" | Decision Summary — every branch resolved, whether viability or execution |
+| `decision-sparring` | "decision sparring", "spar with this decision", "interrogate my idea/plan", "stress-test this", "drill into this", "poke holes in it", "help me think through whether to pursue this" | Decision Summary — every branch resolved, whether viability or execution |
 
 ### softskills Skills
 

--- a/plugins/thinking-tools/.claude-plugin/plugin.json
+++ b/plugins/thinking-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "thinking-tools",
 	"description": "Thinking tools for pressure-testing ideas, exploring assumptions, and sharpening decisions",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"author": {
 		"name": "irfansofyana"
 	}

--- a/plugins/thinking-tools/.claude-plugin/plugin.json
+++ b/plugins/thinking-tools/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "thinking-tools",
 	"description": "Thinking tools for pressure-testing ideas, exploring assumptions, and sharpening decisions",
-	"version": "1.2.1",
+	"version": "1.3.0",
 	"author": {
 		"name": "irfansofyana"
 	}

--- a/plugins/thinking-tools/README.md
+++ b/plugins/thinking-tools/README.md
@@ -7,9 +7,9 @@ Thinking tools for pressure-testing ideas and sharpening decisions before you co
 | Question | Skill |
 |---|---|
 | Should I pursue this idea at all? | idea-refinery |
-| How do I actually build / execute this? | grill-me |
+| What decisions must be resolved before I commit or execute? | decision-sparring |
 
-Natural order: run **idea-refinery** first to validate the idea and produce an Idea Brief, then run **grill-me** to drill into execution.
+Natural order: run **idea-refinery** first to validate the idea and produce an Idea Brief, then run **decision-sparring** to resolve the remaining decision branches.
 
 ## Skills
 
@@ -50,21 +50,20 @@ A sparring partner that challenges your raw ideas through natural conversation, 
 | **Biggest risk** | The single most likely thing to kill this |
 | **Next 3 actions** | Concrete P0/P1/P2 steps |
 
-**Scope:** Viability only — problem-fit, assumptions, risks, and whether this is worth doing. Implementation details are out of scope; that's what grill-me is for.
+**Scope:** Viability only — problem-fit, assumptions, risks, and whether this is worth doing. Implementation details are out of scope; that's what decision-sparring is for.
 
 **Works for any kind of idea:** product features, technical decisions, process changes, org changes, personal projects.
 
-### grill-me
+### decision-sparring
 
-A relentless interrogator that drills into every branch of a plan's decision tree until nothing is unresolved. Probes for unknown unknowns, failure modes, and constraints the user hasn't stated.
-
-Inspired by Matt Pocock's [grill-me skill](https://www.aihero.dev/my-grill-me-skill-has-gone-viral).
+A direct sparring partner that drills into every branch of an idea or plan until nothing important is unresolved. Probes for hidden assumptions, failure modes, tradeoffs, and constraints the user has not stated.
 
 **Trigger phrases:**
-- "grill me"
+- "decision sparring"
+- "spar with this decision"
 - "interrogate my plan"
 - "walk through my design"
-- "stress-test this design"
+- "stress-test this decision"
 - "drill into this plan"
 - "I have a plan, poke holes in it"
 - "I've decided to build X, help me think it through"
@@ -72,12 +71,12 @@ Inspired by Matt Pocock's [grill-me skill](https://www.aihero.dev/my-grill-me-sk
 **What it does:**
 
 1. You share a plan — any type, any format
-2. The agent asks sharp questions one or two at a time, walking every branch of the decision tree and resolving dependencies one-by-one
+2. The agent asks sharp questions one at a time, walking every branch of the decision tree and resolving dependencies one-by-one
 3. When a question has an obvious answer, it offers its lean: "I'd go with X here — does that match your thinking?"
 4. Probes for what you haven't thought to mention: undisclosed constraints, hidden assumptions, overlooked stakeholders, failure modes, and second-order effects of the implementation
 5. If the plan involves code or systems, it can explore the codebase to ground its questions in reality
 
-**Scope:** Execution only — assumes the idea is already validated. Probes implementation details, sequencing, edge cases, and hidden constraints. Does not re-open the question of whether to pursue the idea.
+**Scope:** Viability and execution — useful when a decision still has unresolved branches, whether they are about pursuing the idea, sequencing the work, handling edge cases, or committing to concrete next steps.
 
 **Works for:** technical architecture, product plans, process changes, any decision with multiple moving parts.
 

--- a/plugins/thinking-tools/README.md
+++ b/plugins/thinking-tools/README.md
@@ -56,7 +56,7 @@ A sparring partner that challenges your raw ideas through natural conversation, 
 
 ### decision-sparring
 
-A direct sparring partner that drills into every branch of an idea or plan until nothing important is unresolved. Probes for hidden assumptions, failure modes, tradeoffs, and constraints the user has not stated.
+A direct sparring partner that drills into every branch of an idea, plan, or decision until nothing important is unresolved. Probes for hidden assumptions, failure modes, tradeoffs, and constraints the user has not stated.
 
 **Trigger phrases:**
 - "decision sparring"
@@ -70,11 +70,12 @@ A direct sparring partner that drills into every branch of an idea or plan until
 
 **What it does:**
 
-1. You share a plan — any type, any format
-2. The agent asks sharp questions one at a time, walking every branch of the decision tree and resolving dependencies one-by-one
+1. You share a plan or decision — any type, any format
+2. The agent asks sharp, one-variable questions one at a time, prioritizing the highest-risk branch first
 3. When a question has an obvious answer, it offers its lean: "I'd go with X here — does that match your thinking?"
-4. Probes for what you haven't thought to mention: undisclosed constraints, hidden assumptions, overlooked stakeholders, failure modes, and second-order effects of the implementation
+4. Probes for what you haven't thought to mention: undisclosed constraints, hidden assumptions, overlooked stakeholders, failure modes, success criteria, exit criteria, and second-order effects of the implementation
 5. If the plan involves code or systems, it can explore the codebase to ground its questions in reality
+6. If you stop before everything is resolved, it separates settled decisions from open branches instead of pretending the decision is complete
 
 **Scope:** Viability and execution — useful when a decision still has unresolved branches, whether they are about pursuing the idea, sequencing the work, handling edge cases, or committing to concrete next steps.
 

--- a/plugins/thinking-tools/skills/decision-sparring/SKILL.md
+++ b/plugins/thinking-tools/skills/decision-sparring/SKILL.md
@@ -1,15 +1,16 @@
 ---
-name: grill-me
+name: decision-sparring
 description: >
-  Interrogates any idea or plan relentlessly until every branch of the decision tree is resolved —
+  Pressure-tests any idea or plan through direct decision sparring until every branch is resolved —
   whether the question is "is this worth pursuing?" or "how do I execute this?"
-  Activate when the user says things like "grill me", "interrogate my plan", "interrogate my idea",
-  "stress-test this", "drill into this", "poke holes in it", "help me think through whether to pursue this",
+  Activate when the user says things like "decision sparring", "spar with this decision",
+  "interrogate my plan", "interrogate my idea", "stress-test this", "drill into this",
+  "poke holes in it", "help me think through whether to pursue this",
   "I've decided to do X, help me think it through", or similar.
   Works on any domain — career moves, product launches, hiring plans, technical architecture, business decisions.
 ---
 
-Your job is to interrogate every unresolved branch until there are no open questions left — whether that means questioning whether the idea is worth pursuing, drilling into how to execute it, or both. Follow the questions wherever they lead.
+Your job is to pressure-test every unresolved branch until there are no open questions left — whether that means questioning whether the idea is worth pursuing, drilling into how to execute it, or both. Follow the questions wherever they lead.
 
 Start by confirming the topic in one sentence, then begin. Stay on that topic until it's fully resolved — if the conversation drifts, bring it back. When every branch is closed, produce a **Decision Summary**: a bullet-point list of every decision agreed on, with one final bullet naming the single most important next action.
 

--- a/plugins/thinking-tools/skills/decision-sparring/SKILL.md
+++ b/plugins/thinking-tools/skills/decision-sparring/SKILL.md
@@ -1,47 +1,72 @@
 ---
 name: decision-sparring
 description: >
-  Pressure-tests any idea or plan through direct decision sparring until every branch is resolved —
+  Pressure-tests any idea, plan, or decision through direct decision sparring until every branch is resolved —
   whether the question is "is this worth pursuing?" or "how do I execute this?"
   Activate when the user says things like "decision sparring", "spar with this decision",
   "interrogate my plan", "interrogate my idea", "stress-test this", "drill into this",
   "poke holes in it", "help me think through whether to pursue this",
-  "I've decided to do X, help me think it through", or similar.
-  Works on any domain — career moves, product launches, hiring plans, technical architecture, business decisions.
+  "I've decided to do X, help me think it through", "help me decide", or similar.
+  Works on any domain - career moves, product launches, hiring plans, technical architecture, business decisions.
 ---
 
-Your job is to pressure-test every unresolved branch until there are no open questions left — whether that means questioning whether the idea is worth pursuing, drilling into how to execute it, or both. Follow the questions wherever they lead.
+You are a decision sparring partner. Your job is to pressure-test every unresolved branch until there are no important open questions left - whether that means questioning whether the idea is worth pursuing, drilling into how to execute it, or both. Optimize for committed decisions, not comfort.
 
-Start by confirming the topic in one sentence, then begin. Stay on that topic until it's fully resolved — if the conversation drifts, bring it back. When every branch is closed, produce a **Decision Summary**: a bullet-point list of every decision agreed on, with one final bullet naming the single most important next action.
+On the opening turn, name the topic in one sentence, give a sharp read on the likely risk or decision type, then ask the first question. Stay on that topic until it is resolved. If the conversation drifts, bring it back.
 
 ## How you work
 
-Ask exactly one question per turn — never more. Dumping multiple questions lets the user pick the comfortable ones and sidestep the hard ones.
+Keep an internal branch ledger. Track what is resolved, what is still open, and which branch is highest risk. Do not print the ledger unless the user asks where the conversation stands.
 
-On the opening turn, give a one-sentence read on the topic before asking — what kind of problem this looks like, what the obvious risk is, or what you'd want to understand first. This sets the tone and signals you're paying attention, not just running through a checklist.
+Choose the next branch by risk, not by convenience:
+
+- Fatal assumptions: what would make the whole decision not worth doing?
+- Irreversible or expensive commitments: what is hardest to undo?
+- External dependencies: who or what must cooperate?
+- Execution mechanics: what exactly happens next?
+- Success and exit criteria: how will the user know to continue, stop, or reverse course?
+
+Ask exactly one question per turn - never more. The question must test one decision variable. Do not hide multiple questions behind one question mark, such as "who is this for and why now?" Pick one.
 
 After each answer, do three things before asking the next question:
 
-1. **Assess** — give a real judgment on what was said. Not "that's interesting" or "got it". Say what's solid, what's thin, what's a red flag, or what's missing. Be direct: "that's the right call", "that's a problem", "that's too vague to build on."
+1. **Assess** - give a real judgment on what was said. Not "that's interesting" or "got it". Say what's solid, what's thin, what's a red flag, or what's missing. Be direct: "that's the right call", "that's a problem", "that's too vague to build on."
 
-2. **Recommend** — if you have a view on what they should do, say it. Don't hold your recommendations for the end. If their answer reveals a better path, a mistake they're about to make, or a decision they should make now, name it. "I'd do X before Y", "don't build until you've done Z", "that assumption will cost you — here's what I'd validate first."
+2. **Recommend** - if you have a view on what they should do, say it. Do not hold recommendations for the end. If their answer reveals a better path, a mistake they are about to make, or a decision they should make now, name it. Example: "I'd do X before Y", "don't build until you've done Z", "that assumption will cost you; validate it first."
 
-3. **Probe** — ask the next question to push into the next unresolved branch.
+3. **Probe** - ask the next one-variable question that pushes into the highest-risk unresolved branch.
 
-The goal is to be a thinking partner, not just an interrogator. Each turn should leave them with something concrete — a sharper view of their situation, a recommendation they can act on, and a question that pushes them further.
+The goal is to be a thinking partner, not just an interrogator. Each turn should leave the user with something concrete: a sharper view of the situation, a recommendation they can act on, and one question that moves the decision forward.
 
-If an answer is vague — "we'll figure it out", "probably fine", "not sure yet" — don't move on. Name what's missing and ask again: who specifically, what exactly, by when. Vague answers are where plans fail; push until you have something concrete.
+If an answer is vague - "we'll figure it out", "probably fine", "not sure yet" - do not move on. Name what is missing and ask again for a specific person, number, date, constraint, threshold, or decision. Vague answers are where plans fail.
 
-A branch is resolved only when two things are true: the user has committed to something concrete (a specific number, person, date, or decision), and you've agreed it's sufficient. Signal the close explicitly — "that settles X" — before moving to the next branch. If the user hasn't committed to anything concrete, the branch is still open regardless of how many times you've pushed back.
+A branch is resolved only when two things are true: the user has committed to something concrete, and you agree it is sufficient for the decision at hand. Signal the close explicitly - "that settles X" - before moving to the next branch. If the user has not committed to anything concrete, the branch is still open regardless of how many times you have discussed it.
+
+If the decision involves code, architecture, systems, data, or operations, ground the sparring in reality. Inspect relevant repo files, docs, configs, logs, or APIs when available before asking detailed implementation questions. Do not debate an imagined system when the actual system can be checked.
+
+If the user asks a direct question, answer it briefly with your lean, then return to the sparring loop with one question.
 
 ## What you probe for
 
 Actively look for what the user hasn't thought to mention:
 
-- **Viability** — Is this worth doing? Does it solve a real problem, for a specific person? What assumptions must hold? Why now, and what changes if they wait?
-- **Mechanics** — How exactly does this work, step by step? What's the simplest path? What are the real tradeoffs?
-- **Sequencing & dependencies** — What must happen before what? Who does what? What's the critical path?
-- **Failure modes** — What breaks under stress, edge cases, or bad luck? Fast-forward 6 months: if this failed, what went wrong?
-- **Hidden assumptions** — What constraints haven't been stated? What's being taken for granted — resources, timelines, cooperation, external factors?
+- **Viability** - Is this worth doing? Does it solve a real problem, for a specific person? What assumptions must hold? Why now, and what changes if they wait?
+- **Evidence** - What has the user already observed? What is still belief, taste, hope, or borrowed conviction?
+- **Mechanics** - How exactly does this work, step by step? What is the simplest path? What are the real tradeoffs?
+- **Sequencing and dependencies** - What must happen before what? Who does what? What is the critical path?
+- **Failure modes** - What breaks under stress, edge cases, bad incentives, or bad luck? Fast-forward 6 months: if this failed, what went wrong?
+- **Stakeholders** - Who is affected, who can block it, and who must be aligned before commitment?
+- **Success and exit criteria** - What measurable signal means continue, pause, pivot, or stop?
+- **Hidden assumptions** - What constraints have not been stated? What is being taken for granted: resources, timelines, cooperation, external factors?
 
 Don't move on from a branch until it's resolved.
+
+## How you close
+
+Produce a **Decision Summary** only when all important branches are resolved. Do not initiate an early-stop summary yourself while important branches remain open; continue with one question unless the user explicitly asks to stop or summarize.
+
+When branches are resolved, the Decision Summary is a bullet list of agreed decisions, with one final bullet naming the single most important next action.
+
+When the user asks to stop before resolution, do not pretend the decision is settled. Write a brief summary with two sections: **Settled Decisions** and **Open Branches**. Put only fully committed decisions in **Settled Decisions**. Put partial commitments, unresolved readiness, missing evidence, and caveated ownership in **Open Branches**. The final bullet should name the single next action that would resolve the highest-risk open branch.
+
+Never list an unresolved assumption as an agreed decision. Never force closure just because the conversation has been long.

--- a/plugins/thinking-tools/skills/decision-sparring/evals/evals.json
+++ b/plugins/thinking-tools/skills/decision-sparring/evals/evals.json
@@ -1,10 +1,10 @@
 {
-  "skill_name": "grill-me",
+  "skill_name": "decision-sparring",
   "evals": [
     {
       "id": 1,
       "prompt": "I'm thinking about building a SaaS tool for freelancers to manage invoices.",
-      "expected_output": "A full grill-me session: one question per turn with mentor commentary after each answer, covering viability and execution, ending with a Decision Summary bullet list.",
+      "expected_output": "A full decision-sparring session: one question per turn with mentor commentary after each answer, covering viability and execution, ending with a Decision Summary bullet list.",
       "files": [],
       "expectations": [
         "Each model turn asks exactly one question (no turn has more than one question mark from the model)",
@@ -18,7 +18,7 @@
     {
       "id": 2,
       "prompt": "I've decided to quit my job and go full-time on my side project in 3 months.",
-      "expected_output": "A full grill-me session interrogating execution of this decision — sequencing, finances, dependencies, failure modes — with mentor commentary after each answer and a Decision Summary at the end.",
+      "expected_output": "A full decision-sparring session interrogating execution of this decision — sequencing, finances, dependencies, failure modes — with mentor commentary after each answer and a Decision Summary at the end.",
       "files": [],
       "expectations": [
         "Each model turn asks exactly one question (no turn has more than one question mark from the model)",
@@ -32,7 +32,7 @@
     {
       "id": 3,
       "prompt": "I want to move to a new city for better career opportunities.",
-      "expected_output": "A full grill-me session on this life decision — interrogating viability, execution, hidden assumptions, and failure modes — with mentor commentary and a Decision Summary.",
+      "expected_output": "A full decision-sparring session on this life decision — interrogating viability, execution, hidden assumptions, and failure modes — with mentor commentary and a Decision Summary.",
       "files": [],
       "expectations": [
         "Each model turn asks exactly one question (no turn has more than one question mark from the model)",
@@ -46,7 +46,7 @@
     {
       "id": 4,
       "prompt": "I want to start a podcast about entrepreneurship.",
-      "expected_output": "A full grill-me session where the user gives vague, deflecting answers. The model should push back on each vague answer — naming what's missing and asking again — rather than accepting 'not sure' or 'we'll figure it out' and moving on.",
+      "expected_output": "A full decision-sparring session where the user gives vague, deflecting answers. The model should push back on each vague answer — naming what's missing and asking again — rather than accepting 'not sure' or 'we'll figure it out' and moving on.",
       "files": [],
       "expectations": [
         "Each model turn asks exactly one question (no turn has more than one question mark from the model)",

--- a/plugins/thinking-tools/skills/decision-sparring/evals/evals.json
+++ b/plugins/thinking-tools/skills/decision-sparring/evals/evals.json
@@ -10,6 +10,7 @@
         "Each model turn asks exactly one question (no turn has more than one question mark from the model)",
         "The opening turn includes a framing observation about the topic before asking the first question — not just topic confirmation",
         "Each model turn contains a concrete judgment or observation before the question, not just an acknowledgment like 'Got it' or 'That makes sense'",
+        "Each question tests one decision variable and does not hide multiple questions behind one question mark",
         "The session ends with a Decision Summary section",
         "The model probes viability (is this worth doing, real problem, assumptions)",
         "The model does not jump to a full solution or plan before all branches are resolved"
@@ -24,6 +25,7 @@
         "Each model turn asks exactly one question (no turn has more than one question mark from the model)",
         "The opening turn includes a framing observation about the topic before asking the first question — not just topic confirmation",
         "Each model turn contains a concrete judgment or observation before the question, not just an acknowledgment like 'Got it' or 'That makes sense'",
+        "The model prioritizes the highest-risk branch first: runway, revenue validation, partner alignment, or quit criteria before lower-risk logistics",
         "The session ends with a Decision Summary section",
         "The model probes concrete execution details (finances, timeline, dependencies)",
         "The model gives direct recommendations or leans, not just neutral questions"
@@ -38,6 +40,7 @@
         "Each model turn asks exactly one question (no turn has more than one question mark from the model)",
         "The opening turn includes a framing observation about the topic before asking the first question — not just topic confirmation",
         "Each model turn contains a concrete judgment or observation before the question, not just an acknowledgment like 'Got it' or 'That makes sense'",
+        "The model probes success and exit criteria: what would prove the move worked or should be reversed",
         "The session ends with a Decision Summary section",
         "The model probes hidden assumptions (partner situation, finances, job search timing)",
         "The model shares a clear lean or recommendation at least once during the session"
@@ -53,7 +56,24 @@
         "The opening turn includes a framing observation about the topic before asking the first question",
         "When a user gives a vague answer ('not sure', 'we'll figure it out', 'probably fine'), the model names what's missing and asks again rather than accepting it and moving on",
         "The model does not let the session close while key branches remain unresolved due to vague answers",
+        "If the session ends before resolution, the model separates settled decisions from open branches rather than treating unresolved assumptions as decisions",
+        "The model only produces an early-stop summary when the user asks to stop or summarize",
         "A Decision Summary is only produced once branches are genuinely resolved — the model does not fabricate resolutions or force a close just to produce a summary"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "I want to split our billing logic out of the monolith into a separate service.",
+      "expected_output": "A decision-sparring session that grounds technical questions in the actual system when files are available, prioritizes the riskiest architectural assumptions, asks one non-compound question per turn, and avoids proposing a full architecture before constraints are understood.",
+      "files": [],
+      "expectations": [
+        "The opening turn frames the architectural risk before asking the first question",
+        "Each model turn asks exactly one non-compound question about a single decision variable",
+        "The model asks to inspect or actually inspects relevant code/docs/configs when available before debating detailed implementation choices",
+        "The model prioritizes high-risk architecture branches such as transaction boundaries, data ownership, failure modes, rollback, and operational ownership",
+        "The model gives direct recommendations or leans without jumping to a complete architecture prematurely",
+        "The model does not initiate an early-stop summary while open architecture branches remain unless the user asks to stop",
+        "The session ends with a Decision Summary only after resolved decisions are concrete, or separates Open Branches if the user stops early"
       ]
     }
   ]


### PR DESCRIPTION
## Summary

- Rename the former `grill-me` skill to `decision-sparring` and update references across thinking-tools docs and eval metadata.
- Tighten `decision-sparring` behavior around risk-ordered branch tracking, one-variable questions, technical grounding, and honest closure.
- Expand eval expectations with stricter closure checks and an architecture/system-decision scenario.
- Bump `thinking-tools` plugin version to `1.4.0`.

## Validation

- `make validate`
- `python3 /home/irfansofyana/.codex/skills/.system/skill-creator/scripts/quick_validate.py plugins/thinking-tools/skills/decision-sparring`
- Forward-tested all five `decision-sparring` eval prompts with `codex exec --ephemeral --sandbox read-only`; all self-graded pass.

## Notes

The repository remote reports it moved from `irfansofyana/my-claude-code-marketplace` to `irfansofyana/ai-marketplace`, so this PR targets the new repository location.