### PR TITLE
[codex] Add agentic development workflow skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,6 +23,11 @@
 			"description": "Foundational engineering tools for diagram generation, technical documentation, and development workflows"
 		},
 		{
+			"name": "agentic-development",
+			"source": "./plugins/agentic-development",
+			"description": "Context-scaled AI coding workflows for shared understanding, research, parallel lanes, verification, and handoff"
+		},
+		{
 			"name": "sys-maint",
 			"source": "./plugins/sys-maint",
 			"description": "System maintenance and cleanup utilities for Docker and disk space"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repository serves as a marketplace for reusable agent workflows across agen
 | **[shared-mcp](./plugins/shared-mcp/)** | **INSTALL FIRST** - MCP infrastructure for web search (Brave, Tavily, Exa) | Node.js, BRAVE_API_KEY, TAVILY_API_KEY, EXA_API_KEY |
 | **[p-assist](./plugins/p-assist/)** | Productivity: expenses, RSS, VPS | shared-mcp, N8N_API_TOKEN |
 | **[common-engineering](./plugins/common-engineering/)** | Engineering tools: code review, Mermaid diagrams, tech docs (RFCs, proposals, ADRs), web research | shared-mcp, optional pi-9router-ext + @tintinweb/pi-subagents, mermaid-cli, CONTEXT7_API_KEY |
+| **[agentic-development](./plugins/agentic-development/)** | Context-scaled AI coding workflows: shared understanding, research gates, parallel lanes, verification, and handoff artifacts | None |
 | **[sys-maint](./plugins/sys-maint/)** | System maintenance: Docker cleanup, disk analysis | macOS only |
 | **[thinking-tools](./plugins/thinking-tools/)** | Thinking tools: pressure-test ideas (idea-refinery) and resolve decision branches (decision-sparring) | None |
 | **[softskills](./plugins/softskills/)** | Office politics coach for navigating workplace dynamics | None |
@@ -22,6 +23,17 @@ See individual plugin READMEs for detailed setup instructions.
 ## Available Skills
 
 Skills are model-invoked capabilities that agent runtimes can activate when triggered by natural language. They are organized by plugin:
+
+### agentic-development Skills
+
+| Skill | Trigger Phrases | Output |
+|-------|-----------------|--------|
+| `agentic-development` | starting/planning/implementing/refactoring/debugging/verifying non-trivial AI-assisted development work | Context-scaled development loop with the smallest safe mode and routed gates |
+| `shared-understanding` | vague request, "grill me", unclear scope, challenge assumptions, unsure what to build | One-question-at-a-time clarification until goal, scope, constraints, success criteria, and next action are clear |
+| `research-gate` | latest/current docs, prior art, best practices, external API, error message, migration, comparison | Research decision with source links when research is used, or a clear skip reason |
+| `parallel-lanes` | subagents, parallel research, independent validation/review/inventory lanes | Lane plan and synthesis for subagents, parallel tool calls, or sequential fallback |
+| `verification-gate` | verify changes, choose tests/checks, prove it works, manual QA, Terraform validate/plan | Project-shaped verification evidence and remaining risk |
+| `workflow-artifact` | large/risky/multi-session/multi-agent work, handoff, durable plan | `docs/ai-workflow/YYYY-MM-DD-<task-slug>.md` live artifact for continuity |
 
 ### common-engineering Skills
 
@@ -77,6 +89,7 @@ Reload: `source ~/.zshrc` or `source ~/.bashrc`
 /plugin install shared-mcp@ai-marketplace     # REQUIRED - install first
 /plugin install p-assist@ai-marketplace       # Optional
 /plugin install common-engineering@ai-marketplace  # Optional
+/plugin install agentic-development@ai-marketplace # Optional
 /plugin install sys-maint@ai-marketplace      # Optional (macOS only)
 /plugin install thinking-tools@ai-marketplace # Optional
 /plugin install softskills@ai-marketplace     # Optional

--- a/plugins/agentic-development/.claude-plugin/plugin.json
+++ b/plugins/agentic-development/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "agentic-development",
+  "description": "Context-scaled AI coding workflows for shared understanding, research, parallel lanes, verification, and handoff",
+  "version": "1.0.0",
+  "author": {
+    "name": "irfansofyana"
+  }
+}

--- a/plugins/agentic-development/README.md
+++ b/plugins/agentic-development/README.md
@@ -1,0 +1,26 @@
+# agentic-development
+
+Context-scaled AI coding workflows for getting from intent to verified changes without turning every task into a ceremony.
+
+## Design Principle
+
+The root skill chooses the smallest reliable development mode; focused gate skills own alignment, research, parallelism, artifacts, and verification.
+
+## Skills
+
+| Skill | Use When |
+|---|---|
+| `agentic-development` | Starting, planning, implementing, refactoring, debugging, or verifying non-trivial development work |
+| `shared-understanding` | The request is vague, exploratory, conflicted, or needs assumptions challenged |
+| `research-gate` | Fresh external knowledge, prior art, current docs, errors, or best practices may affect the answer |
+| `parallel-lanes` | Research, exploration, validation, review, or implementation can be split into independent lanes |
+| `verification-gate` | Choosing or running the checks that prove a development change works |
+| `workflow-artifact` | Large/risky, multi-session, multi-agent, interrupted, or continuity-heavy medium work needs durable task memory |
+
+## Installation
+
+```bash
+/plugin install agentic-development@ai-marketplace
+```
+
+No API keys or external dependencies required. Web research and subagent behavior use whatever tools the active AI coding agent already provides.

--- a/plugins/agentic-development/skills/agentic-development/SKILL.md
+++ b/plugins/agentic-development/skills/agentic-development/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: agentic-development
+description: Use when a development task is unclear, multi-step, risky, or needs coordinated gates for shared understanding, research, parallel lanes, workflow artifacts, and verification. For a single concern, invoke the specific gate; for tiny mechanical changes, skip unless the user asks.
+---
+
+# Agentic Development
+
+Use the smallest reliable development loop. Expand only when ambiguity, risk, external facts, or coordination demand it.
+
+## First Pass
+
+1. Read and follow applicable local instruction files: `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `.cursor/rules`, `.github/copilot-instructions.md`, or equivalents. Complete when you can name which files existed and which constraints affect the task.
+2. Inspect the repo area likely touched by the request, including related tests/config when present. Complete when you can name the involved files/components and which questions the codebase answered.
+3. Choose a mode using the table. Complete when you have stated the mode and the trigger(s) that justify it.
+
+| Mode | Use When | Loop |
+|---|---|---|
+| Tiny | Mechanical, obvious, low-risk | Inspect -> change -> verify -> summarize |
+| Small | Clear goal, limited files | Inspect -> short plan -> change -> verify -> summarize |
+| Medium | Some ambiguity, behavior change, several files | Clarify if needed -> plan checklist -> implement slices -> verify |
+| Large/Risky | Broad scope, migration, architecture, security, production risk, multi-session | Artifact -> shared understanding -> research/parallel lanes -> plan -> slices -> verify -> handoff |
+
+## Gates
+
+- **Shared understanding:** If intent is vague, conflicted, or underspecified, invoke `shared-understanding`.
+- **Research:** If current or external knowledge could change the answer, invoke `research-gate`.
+- **Parallel lanes:** For medium/large work with independent research, exploration, validation, or review, invoke `parallel-lanes`.
+- **Artifact:** For large/risky, multi-agent, interrupted, multi-session, or continuity-heavy medium work, invoke `workflow-artifact`.
+- **Verification:** Before saying done, invoke `verification-gate`.
+
+## Scope Control
+
+Classify discovered adjacent work:
+
+- **Blocking:** required for the requested work to be correct; fix now.
+- **Related:** useful but not required; ask before doing.
+- **Parking lot:** document only.
+
+Do not commit by default. Commit only when the user asks or the repo workflow explicitly requires it.
+
+## Completion Criterion
+
+Stop only when the requested change is implemented or deliberately deferred, every triggered gate has passed or is explicitly blocked, verification evidence is available, and the final response names what changed, what was verified, and any remaining risk.

--- a/plugins/agentic-development/skills/agentic-development/SKILL.md
+++ b/plugins/agentic-development/skills/agentic-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentic-development
-description: Use when a development task is unclear, multi-step, risky, or needs coordinated gates for shared understanding, research, parallel lanes, workflow artifacts, and verification. For a single concern, invoke the specific gate; for tiny mechanical changes, skip unless the user asks.
+description: Use when a development task is unclear, multi-step, risky, or needs coordinated gates for shared understanding, research, parallel lanes, workflow artifacts, and verification. For a single concern, use the matching gate skill if available; for tiny mechanical changes, skip unless the user asks.
 ---
 
 # Agentic Development
@@ -13,20 +13,26 @@ Use the smallest reliable development loop. Expand only when ambiguity, risk, ex
 2. Inspect the repo area likely touched by the request, including related tests/config when present. Complete when you can name the involved files/components and which questions the codebase answered.
 3. Choose a mode using the table. Complete when you have stated the mode and the trigger(s) that justify it.
 
-| Mode | Use When | Loop |
-|---|---|---|
-| Tiny | Mechanical, obvious, low-risk | Inspect -> change -> verify -> summarize |
-| Small | Clear goal, limited files | Inspect -> short plan -> change -> verify -> summarize |
-| Medium | Some ambiguity, behavior change, several files | Clarify if needed -> plan checklist -> implement slices -> verify |
-| Large/Risky | Broad scope, migration, architecture, security, production risk, multi-session | Artifact -> shared understanding -> research/parallel lanes -> plan -> slices -> verify -> handoff |
+| Mode | Use When | Example | Loop |
+|---|---|---|---|
+| Tiny | Mechanical, obvious, low-risk | Rename a variable, format one file, fix a typo | Inspect -> change -> verify -> summarize |
+| Small | Clear goal, limited files | Add one config value, adjust a narrow helper and test | Inspect -> short plan -> change -> verify -> summarize |
+| Medium | Some ambiguity, behavior change, several files | Add a field across API/schema/UI, refactor a module | Clarify if needed -> plan checklist -> implement slices -> verify |
+| Large/Risky | Broad scope, migration, architecture, security, production risk, multi-session | Auth rewrite, data migration, cross-service rollout | Artifact -> alignment -> research/lanes -> plan -> slices -> verify -> handoff |
 
 ## Gates
 
-- **Shared understanding:** If intent is vague, conflicted, or underspecified, invoke `shared-understanding`.
-- **Research:** If current or external knowledge could change the answer, invoke `research-gate`.
-- **Parallel lanes:** For medium/large work with independent research, exploration, validation, or review, invoke `parallel-lanes`.
-- **Artifact:** For large/risky, multi-agent, interrupted, multi-session, or continuity-heavy medium work, invoke `workflow-artifact`.
-- **Verification:** Before saying done, invoke `verification-gate`.
+Gate skills are portable instruction sets, not callable subroutines. When a gate applies, load and follow the named `agentic-development:<skill>` skill if the runtime exposes it. If another skill cannot be loaded directly, use the fallback behavior in that bullet.
+
+- **Shared understanding (`agentic-development:shared-understanding`):** If intent is vague, conflicted, or underspecified, read and follow this gate; otherwise ask one question at a time until the task is clear.
+- **Research (`agentic-development:research-gate`):** If current or external knowledge could change the answer, read and follow this gate; otherwise research first and verify sources before relying on the answer.
+- **Parallel lanes (`agentic-development:parallel-lanes`):** For medium/large work with independent research, exploration, validation, or review, read and follow this gate; otherwise split independent work into sequential lanes and synthesize findings.
+- **Artifact (`agentic-development:workflow-artifact`):** For large/risky, multi-agent, interrupted, multi-session, or continuity-heavy medium work, read and follow this gate; otherwise keep a concise written handoff in the working context.
+- **Verification (`agentic-development:verification-gate`):** Before saying done, read and follow this gate; otherwise run the strongest practical verification and report evidence.
+
+## Commit Policy
+
+Do not commit by default. Commit only when the user asks or the repo workflow explicitly requires it.
 
 ## Scope Control
 
@@ -35,8 +41,6 @@ Classify discovered adjacent work:
 - **Blocking:** required for the requested work to be correct; fix now.
 - **Related:** useful but not required; ask before doing.
 - **Parking lot:** document only.
-
-Do not commit by default. Commit only when the user asks or the repo workflow explicitly requires it.
 
 ## Completion Criterion
 

--- a/plugins/agentic-development/skills/parallel-lanes/SKILL.md
+++ b/plugins/agentic-development/skills/parallel-lanes/SKILL.md
@@ -7,6 +7,10 @@ description: Use when development work has independent lanes for research, codeb
 
 Use parallelism when independence is real.
 
+## Capability Check
+
+Before defining lanes, name the available execution mechanism: subagents, parallel tool calls, or sequential fallback. If the runtime has no subagent or parallel-tool support, collapse the lanes into sequential tasks while keeping the same lane contract and synthesis.
+
 ## When To Use
 
 - Tiny work: skip.
@@ -14,6 +18,8 @@ Use parallelism when independence is real.
 - Medium/large work: use when available for research, codebase exploration, migration inventory, validation, review, UI checks, or security passes.
 
 ## Lane Hierarchy
+
+Use the strongest available mechanism:
 
 1. Subagents for independent reasoning or fresh-eye review.
 2. Parallel tool calls for independent file reads, searches, metadata checks, or commands.

--- a/plugins/agentic-development/skills/parallel-lanes/SKILL.md
+++ b/plugins/agentic-development/skills/parallel-lanes/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: parallel-lanes
+description: Use when development work has independent lanes for research, codebase exploration, inventory, validation, review, or non-overlapping implementation that can run in subagents, parallel tool calls, or separately owned workstreams.
+---
+
+# Parallel Lanes
+
+Use parallelism when independence is real.
+
+## When To Use
+
+- Tiny work: skip.
+- Small work: use opportunistically for independent reads/searches.
+- Medium/large work: use when available for research, codebase exploration, migration inventory, validation, review, UI checks, or security passes.
+
+## Lane Hierarchy
+
+1. Subagents for independent reasoning or fresh-eye review.
+2. Parallel tool calls for independent file reads, searches, metadata checks, or commands.
+3. Sequential fallback when neither is available.
+
+## Lane Contract
+
+Define each lane with:
+
+- question or task;
+- allowed scope;
+- files or systems to avoid;
+- expected output;
+- stop condition.
+
+The main agent owns synthesis, decisions, and final user communication.
+
+## Edit Safety
+
+Default lanes are research, exploration, and validation. Editing lanes are allowed only when file ownership is clearly non-overlapping. If ownership is unclear, lanes report findings and the main agent applies edits.
+
+## Completion Criterion
+
+Every lane has a result, gap, or blocked reason. Before leaving the gate, each gap or blocker is resolved by the main agent, marked non-blocking with reason, added to the plan/artifact as follow-up, or escalated to the user. The main agent has synthesized how the lane output changes the plan.

--- a/plugins/agentic-development/skills/research-gate/SKILL.md
+++ b/plugins/agentic-development/skills/research-gate/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: research-gate
+description: "Use when development work depends on current or external facts: latest docs/APIs, library or platform behavior, security guidance, unfamiliar errors, migrations, comparisons, best practices, prior art, or known fixes."
+---
+
+# Research Gate
+
+Research is for reducing uncertainty, not for delaying local work.
+
+## Decide
+
+Inspect local docs and code first when the answer may be repo-defined.
+
+Use external research when:
+
+- facts may have changed recently;
+- external APIs, frameworks, providers, models, packages, deployment, CI, browsers, platforms, or security guidance matter;
+- the user asks for latest, recommended, compare, best practice, known fix, or prior art;
+- an error message or failing tool output is unfamiliar;
+- guessing would shape the implementation;
+- repeated attempts failed.
+
+Skip research when the answer is clearly local, mechanical, or already covered by authoritative repo docs/tests. If skipped, say why briefly.
+
+## Source Order
+
+Prefer sources in this order:
+
+1. Official docs, specs, release notes, changelogs.
+2. Maintainer issues, discussions, migration guides.
+3. Reputable engineering writeups, incident reports, benchmarks.
+4. Community posts only when they explain a reproducible symptom or workaround.
+
+## Citation Rule
+
+When research is used, cite source links in the answer. For medium/large work, also record important links and date-sensitive findings in the live workflow artifact.
+
+## Completion Criterion
+
+End the gate only after local docs/code have been inspected or explicitly ruled out. If research is used, record each implementation-shaping finding, its authoritative source link, version/date constraints, conflicts or unavailable authoritative sources, and implementation impact. If research is skipped, state the repo-local evidence that makes it unnecessary.

--- a/plugins/agentic-development/skills/shared-understanding/SKILL.md
+++ b/plugins/agentic-development/skills/shared-understanding/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: shared-understanding
+description: Use when a development request is vague, exploratory, conflicted, under-specified, or the user says they are unsure, wants to be grilled, wants assumptions challenged, or needs goal, scope, constraints, and success criteria clarified before planning or implementation.
+---
+
+# Shared Understanding
+
+Reach alignment before planning or building. The discipline is one question at a time.
+
+## Loop
+
+1. Inspect the repo instead of asking anything local files can answer.
+2. State your current understanding in one short sentence when it helps frame the next branch.
+3. Ask exactly one question.
+4. Include `My recommendation:` with the answer you would choose and why.
+5. Wait for the user's reply before asking the next question.
+
+## What To Resolve
+
+Resolve only branches that materially affect the work:
+
+- goal and non-goals;
+- user value or success criteria;
+- scope boundaries and constraints;
+- risky assumptions;
+- sequencing and rollback needs;
+- verification expectations.
+
+Challenge assumptions when they affect correctness, cost, maintainability, scope, or user value. Do not challenge harmless preferences.
+
+## Completion Criterion
+
+Shared understanding is reached only when every material branch in What To Resolve is answered by repo evidence or the user, explicitly accepted as an assumption with risk, or deliberately deferred. Then state:
+
+- goal;
+- scope and out of scope;
+- key constraints;
+- success criteria;
+- next action.
+
+Ask for confirmation if the next step would change files or commit to a plan.

--- a/plugins/agentic-development/skills/verification-gate/SKILL.md
+++ b/plugins/agentic-development/skills/verification-gate/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: verification-gate
+description: Use before saying development work is done, or when choosing project-shaped tests/checks to prove code behavior, bug fixes, refactors, config, infrastructure, or UI changes.
+---
+
+# Verification Gate
+
+Never call work done without evidence or an explicit unverifiable reason.
+
+## Choose Project-Shaped Evidence
+
+First inspect the repo's verification culture:
+
+- test commands, lint, typecheck, build, CI, scripts;
+- framework conventions;
+- manual QA notes;
+- examples and smoke tests;
+- infrastructure checks such as `terraform fmt`, `terraform validate`, `terraform plan`, policy checks, or dry runs.
+
+Use TDD when the project structure supports it and the change is behavioral enough to benefit. Do not introduce a new test framework just to satisfy this workflow unless the user approves.
+
+## Run What You Can
+
+- Code behavior: targeted tests first, then broader checks when risk warrants.
+- Bug fixes: reproduce or add a regression check when feasible.
+- Refactors: verify before/after behavior with existing checks.
+- UI changes: use browser/screenshot/manual visual checks when available.
+- Docs/config: run repo validators, formatters, or install checks when available.
+
+Ask the user for manual verification only when credentials, protected environments, real devices, or subjective product judgment are required.
+
+## Completion Criterion
+
+The gate passes only when every relevant changed surface has a chosen check or an explicit unverifiable reason; all run checks pass, or each failure is classified as existing, unrelated, environment-blocked, or intentionally accepted by the user; change-caused failures are fixed and rerun or the work is stopped as blocked. The final report lists commands/checks, results, manual checks, gaps, and residual risk.

--- a/plugins/agentic-development/skills/workflow-artifact/SKILL.md
+++ b/plugins/agentic-development/skills/workflow-artifact/SKILL.md
@@ -17,6 +17,16 @@ docs/ai-workflow/YYYY-MM-DD-<task-slug>.md
 
 Use an existing repo convention instead when one is obvious.
 
+If the path already exists, update it when it is the same task. For a different task on the same day, append a short distinguishing suffix such as `-2` or a more specific slug.
+
+## Lifecycle
+
+Default to a repository document that is eligible for version control, not a gitignored scratch file, when the artifact is meant to survive agent sessions. Do not commit it unless the user asks or the repo workflow explicitly requires it.
+
+Use a repo-ignored scratch location only when the artifact is local-only or disposable. Mark scratch artifacts clearly and delete them before finishing unless they are still needed for handoff.
+
+When the task completes, set Current Status to `Done`, `Blocked`, or `Handoff`, refresh Verification and Handoff, and either keep the artifact as useful project memory or remove/archive it if it was only live working state.
+
 ## When To Create Or Update
 
 Create before implementation for large/risky, multi-agent, interrupted, multi-session, or continuity-heavy medium work. Update after meaningful plan changes, consequential decisions, research findings, verification, interruption, or handoff.

--- a/plugins/agentic-development/skills/workflow-artifact/SKILL.md
+++ b/plugins/agentic-development/skills/workflow-artifact/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: workflow-artifact
+description: Use when development work is large, risky, multi-session, multi-agent, interrupted, or needs durable plan/handoff memory for continuity across coding agents.
+---
+
+# Workflow Artifact
+
+Create durable task memory when chat context is not enough.
+
+## Path
+
+Default path:
+
+```text
+docs/ai-workflow/YYYY-MM-DD-<task-slug>.md
+```
+
+Use an existing repo convention instead when one is obvious.
+
+## When To Create Or Update
+
+Create before implementation for large/risky, multi-agent, interrupted, multi-session, or continuity-heavy medium work. Update after meaningful plan changes, consequential decisions, research findings, verification, interruption, or handoff.
+
+Do not create artifacts for tiny work unless the user asks.
+
+## Template
+
+```markdown
+# <Task Title>
+
+## Goal
+
+## Mode
+
+Tiny | Small | Medium | Large/Risky
+
+## Current Status
+
+## Local Instructions
+
+Project instruction files consulted and notable constraints.
+
+## Decisions
+
+Consequential decisions only. Include rejected approaches when useful.
+
+## Research
+
+Source links, date-sensitive findings, and implementation impact.
+
+## Plan
+
+Checklist of current work slices.
+
+## Key Areas
+
+Important files, modules, tests, config, or docs. Not a full changelog.
+
+## Verification
+
+Commands, checks, results, manual steps, and gaps.
+
+## Open Questions And Risks
+
+## Handoff
+
+What the next agent should do first.
+```
+
+## Completion Criterion
+
+The artifact is complete only when every template section is present and non-empty or marked `N/A` with a reason; Current Status, Plan, Verification, Open Questions And Risks, and Handoff match the latest work; and Handoff names the exact next action a fresh agent should take first.


### PR DESCRIPTION
## Summary

- Add the `agentic-development` plugin with portable skills for shared understanding, research gates, parallel lanes, verification, and workflow artifacts.
- Update marketplace/plugin listings so the new workflow is discoverable.
- Refine root gate routing language, mode calibration examples, artifact lifecycle rules, parallel fallback behavior, and commit policy guidance.

## Validation

- `quick_validate.py` for the edited `agentic-development`, `workflow-artifact`, and `parallel-lanes` skills
- `make validate`
- `git diff --check`